### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -20,7 +20,7 @@ module.exports = {
 
   // Runtime configuration
   publicRuntimeConfig: {
-    version: '1.9.0',
+    version: '1.10.0',
     proposalId: '360',
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Actifit is an innovative dapp that aims to incentivize fitness and healthy lifestyle via rewarding daily activity.",
   "author": "mktcode",
   "private": true,


### PR DESCRIPTION
## Summary

Bumps version from 1.9.0 to 1.10.0 in both `package.json` and `nuxt.config.js` to reflect the security hardening, signup redesign, and UX improvements shipped in PR #278.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)