### PR TITLE
release: v1.10.1 — security hardening, reward verification & signup overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ dist
 .env
 .vscode/launch.json
 .vscode/settings.json
+
+# Security audit reports
+AUDIT-*.md

--- a/components/BuyOptionsModal.vue
+++ b/components/BuyOptionsModal.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div :class="classContxt" id="buyOptionsModal" ref="buyOptionsModal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
       <div class="modal-content">
@@ -19,7 +19,7 @@
 					<a href="https://hive-engine.com/?p=market&t=AFIT" class="btn btn-brand btn-lg border" target="_blank" rel="noopener noreferrer">{{ $t('buy_afit_he') }}</a>
 					</div>
 					<div class="row">
-					<a href="/wallet" class="btn btn-brand btn-lg border" target="_blank" >{{ $t('Move_AFIT_to_Wallet') }}</a>
+					<a href="/wallet" class="btn btn-brand btn-lg border" target="_blank" rel="noopener noreferrer" >{{ $t('Move_AFIT_to_Wallet') }}</a>
 					</div>
 				</div>
 				<div class="col-sm-12 col-md-6">

--- a/components/CardHeader.vue
+++ b/components/CardHeader.vue
@@ -1,6 +1,6 @@
-<template>
+﻿<template>
   <h6 class="mb-0 text-center card-title">
-    <a :href="link" target="_blank">
+    <a :href="link" target="_blank" rel="noopener noreferrer">
       {{ truncateString(title, 70) }}
       <i class="fas fa-external-link-alt"></i>
       <!-- "rewarded" checkmark icon -->

--- a/components/Community.vue
+++ b/components/Community.vue
@@ -1,10 +1,10 @@
-<template>
+﻿<template>
   <!-- single post item for activity pages -->
   <div >
     <div class="card post" :class="{'card-subscribed':userSubscribed}">
       <h6 class="mb-0 text-center post-title">
-        <!--<a :href="community.url" target="_blank">-->
-		<a :href="buildLink+'/posts'" target="_blank">
+        <!--<a :href="community.url" target="_blank" rel="noopener noreferrer">-->
+		<a :href="buildLink+'/posts'" target="_blank" rel="noopener noreferrer">
           {{ truncateString(community.title, 70) }}
 		  <i class="fas fa-external-link-alt"></i>
         </a>
@@ -19,10 +19,10 @@
 		  </div>
           <div class="col-6">
 			<!--<small class="text-muted d-block" :title="date">Created {{ $getTimeDifference(this.community.created_at) }}</small>-->
-			<div ><a :href="buildLink" target="_blank" class="text-brand">#{{community.name}}</a></div>
+			<div ><a :href="buildLink" target="_blank" rel="noopener noreferrer" class="text-brand">#{{community.name}}</a></div>
 			<div>{{community.about}}</div>
 			<small class="text-right curs-point" :title="'Created '+date"><i class="fas fa-calendar"></i>&nbsp;Since {{date}}</small>
-            <!--<a :href="'/'+community.author" target="_blank">
+            <!--<a :href="'/'+community.author" target="_blank" rel="noopener noreferrer">
 
               <div class="user-avatar mr-1"
                    :style="'background-image: url('+profImgUrl+'/u/' + community.author + '/avatar)'"></div>

--- a/components/CompetitionAnnounce.vue
+++ b/components/CompetitionAnnounce.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div :class="outserSmallScreenClasses" class="position-fixed text-brand mx-auto w-100 acti-notify-comp" >
 	<div :class="smallScreenClasses" class="text-center mx-auto acti-notify-comp-inner border-2 rounded">
 	  <div class="announce-title">Actifit Growth & Development Plans 2024 - Vote For Our DHF Proposal!<!-- CryptoFitChallenge 2022 is ON - Final Week In Progress -->
@@ -15,11 +15,11 @@
 			<img class="announce-img" src="/img/dhf_image_2.png" >
 		  </div>
 		  <div class="p-2">
-			  <!--<a href="https://actifit.io/@actifit/we-have-winners-public-token-sale-kicks-off-today-t-7-hours" class="btn btn-brand m-2" target="_blank">Event Details</a>
-			  <a href="https://www.youtube.com/watch?v=Vc6rpDU99nk" class="btn btn-brand m-2 acti-shadow" target="_blank">Video Announcement</a> -->
-			  <a href="https://actifit.io/@actifit/actifit-proposal-year-2--growing-hive-via-collabs-development-infrastructure--onboarding" target="_blank" class="btn btn-brand acti-shadow">Announcement</a>
-			  <a href="https://peakd.com/proposals/292" target="_blank" class="btn btn-brand acti-shadow">Vote Now!</a>
-			  <!--<a href="https://digifinex.zendesk.com/hc/en-us/articles/6871357968793" class="btn btn-brand m-2 back-red" target="_blank">Participation Rules</a>-->
+			  <!--<a href="https://actifit.io/@actifit/we-have-winners-public-token-sale-kicks-off-today-t-7-hours" class="btn btn-brand m-2" target="_blank" rel="noopener noreferrer">Event Details</a>
+			  <a href="https://www.youtube.com/watch?v=Vc6rpDU99nk" class="btn btn-brand m-2 acti-shadow" target="_blank" rel="noopener noreferrer">Video Announcement</a> -->
+			  <a href="https://actifit.io/@actifit/actifit-proposal-year-2--growing-hive-via-collabs-development-infrastructure--onboarding" target="_blank" rel="noopener noreferrer" class="btn btn-brand acti-shadow">Announcement</a>
+			  <a href="https://peakd.com/proposals/292" target="_blank" rel="noopener noreferrer" class="btn btn-brand acti-shadow">Vote Now!</a>
+			  <!--<a href="https://digifinex.zendesk.com/hc/en-us/articles/6871357968793" class="btn btn-brand m-2 back-red" target="_blank" rel="noopener noreferrer">Participation Rules</a>-->
 		  </div>
 		  <div style="display:none"><span class="end-string">Event ends in </span><Countdown v-if="countDownReady" deadline="August 5, 2022 23:59 GMT"></Countdown><i v-else class="fas fa-spin fa-spinner text-brand"></i></div>
 		</div>

--- a/components/ExchangeHistoryModal.vue
+++ b/components/ExchangeHistoryModal.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div class="modal fade" id="exchangeHistoryModal" ref="exchangeHistoryModal" tabindex="-1">
     <div class="modal-dialog modal-lg" role="document">
       <div class="modal-content">
@@ -20,7 +20,7 @@
 			  </thead>
 			  <tbody>
 				<tr v-for="histTrans in transList" :key="histTrans._id" :class="{'bg-danger': !histTrans.upvote_processed, 'text-white': !histTrans.upvote_processed}">
-				  <td class="d-none d-md-table-cell"><a :href="histTrans.user " target="_blank">@{{ histTrans.user }}</a></td>
+				  <td class="d-none d-md-table-cell"><a :href="histTrans.user " target="_blank" rel="noopener noreferrer">@{{ histTrans.user }}</a></td>
 				  <td>{{date(histTrans.date)}}</td>
 				  <td>{{ histTrans.paid_afit }}</td>
 				  <td v-if="histTrans.upvote_processed && !histTrans.refunded">{{ $t('Complete') }}</td>

--- a/components/ExchangeQueueModal.vue
+++ b/components/ExchangeQueueModal.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div class="modal fade" id="exchangeQueueModal" ref="exchangeQueueModal" tabindex="-1">
     <div class="modal-dialog modal-lg" role="document">
       <div class="modal-content">
@@ -26,7 +26,7 @@
 				<tr v-for="(topHolder, key) in topAFITXList" :key="key" :class="{'bg-danger': user === topHolder.account, 'text-white': user === topHolder.account}" v-if="exchangeRequestSet(topHolder.account)">
 				  <td>{{ key + 1 }}</td>
 				  <td>
-					<a :href="topHolder.account" target="_blank" :class="{'text-white': user === topHolder.account}">
+					<a :href="topHolder.account" target="_blank" rel="noopener noreferrer" :class="{'text-white': user === topHolder.account}">
 						@{{ topHolder.account }}
 					</a>
 				  </td>
@@ -52,7 +52,7 @@
 				<tr v-for="(pendingTrans, key) in transList" :key="pendingTrans._id" :class="{'bg-danger': user === pendingTrans.user, 'text-white': user === pendingTrans.user}" v-if="!isTopHolder(pendingTrans.user)">
 				  <th scope="row">{{ key + 1 }}</th>
 				  <td>
-					<a :href="pendingTrans.user" target="_blank" :class="{'text-white': user === pendingTrans.user}">
+					<a :href="pendingTrans.user" target="_blank" rel="noopener noreferrer" :class="{'text-white': user === pendingTrans.user}">
 						@{{ pendingTrans.user }}
 					</a>
 				  </td>

--- a/components/FriendshipModal.vue
+++ b/components/FriendshipModal.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div :class="outserSmallScreenClasses" class="position-fixed text-brand mx-auto w-100 acti-notify-comp" v-if="innerShowModal || showCompDetails" id="friendshipModal" tabindex="-1">
 	<div :class="smallScreenClasses" class="text-center mx-auto acti-notify-comp-inner-friend border-2 rounded" role="document">
 	  <div :class="titleClass" class="row max-acti-width text-white mx-auto px-2">
@@ -23,13 +23,13 @@
 		<div v-if="suggFriendsLoader"><i class="fas fa-spin fa-spinner"></i></div>
 		<div v-else v-for="(suggestion, index) in suggestedFriends" :key="index" :suggestion="suggestion" :class="suggEntryClass">
 			<div class="col-md-4">
-				<a :href="formattedProfileUrl(suggestion.author)" target="_blank">
+				<a :href="formattedProfileUrl(suggestion.author)" target="_blank" rel="noopener noreferrer">
 					<div class="user-avatar large-avatar mr-1"
 					   :style="'background-image: url('+profImgUrl+'/u/' + suggestion.author + '/avatar)'"></div>
 				</a>
 			</div>
 			<div class="col-md-7 mini-user-card text-left">
-				<span><a :href="formattedProfileUrl(suggestion.author)" target="_blank">@{{ suggestion.author }}</a></span>
+				<span><a :href="formattedProfileUrl(suggestion.author)" target="_blank" rel="noopener noreferrer">@{{ suggestion.author }}</a></span>
 				<span v-if="suggestion.rank != null" class="text-brand numberCircle d-none d-md-inline " >{{ displayCoreUserRank(suggestion.rank) }} <span class="increased-rank">{{ displayIncreasedUserRank(suggestion.rank) }}</span></span>
 				<span v-else><i class="fas fa-spin fa-spinner"></i></span>
 				

--- a/components/GenericTopHoldersModal.vue
+++ b/components/GenericTopHoldersModal.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div :id="modalId" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog modal-lg" role="document">
       <div class="modal-content">
@@ -39,7 +39,7 @@
                 <td>{{ topHolder.rank }}</td>
                 <td>
                   <!-- Check if account is truthy AND not the string 'null' before rendering link -->
-                  <a v-if="topHolder.account && topHolder.account !== 'null'" :href="`https://actifit.io/@${topHolder.account}`" target="_blank" :class="{'text-white': user === topHolder.account}">
+                  <a v-if="topHolder.account && topHolder.account !== 'null'" :href="`https://actifit.io/@${topHolder.account}`" target="_blank" rel="noopener noreferrer" :class="{'text-white': user === topHolder.account}">
                     @{{ topHolder.account }}
                   </a>
                   <!-- If account is null (or the string 'null'), display 'null' -->

--- a/components/NewFooterDesign.vue
+++ b/components/NewFooterDesign.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <!-- The `dark-mode` class on a parent will activate the dark theme styles -->
   <footer class="new-footer-container">
     <div class="container">
@@ -13,10 +13,10 @@
            {{ $t('footer_slogan') }}
           </p>
           <div class="app-store-buttons">
-            <a href="https://links.actifit.io/android" target="_blank">
+            <a href="https://links.actifit.io/android" target="_blank" rel="noopener noreferrer">
               <img src="/img/google-play.png" alt="Get it on Google Play">
             </a>
-            <a href="https://links.actifit.io/ios" target="_blank">
+            <a href="https://links.actifit.io/ios" target="_blank" rel="noopener noreferrer">
               <img src="/img/app-store.png" alt="Download on the App Store">
             </a>
           </div>
@@ -29,7 +29,7 @@
           <a href="/market" @click.prevent="$router.push('/market')">{{ $t('Market') }}</a>
           <a href="/yieldfarming" @click.prevent="$router.push('/yieldfarming')">{{ $t('yield_farming') }}</a>
           <a href="/referrals" @click.prevent="$router.push('/referrals')">{{ $t('Refer_A_Friend') }}</a>
-          <a href="/whitepaper/Actifit_White_Paper.pdf" target="_blank">{{ $t('Whitepaper') }}</a>
+          <a href="/whitepaper/Actifit_White_Paper.pdf" target="_blank" rel="noopener noreferrer">{{ $t('Whitepaper') }}</a>
           <a href="/faq">{{ $t('FAQ') }}</a>
         </div>
 
@@ -38,24 +38,24 @@
           <h4>HIVE</h4>
           <a href="/communities">{{ $t('Communities') }}</a>
           <a href="/explore">{{ $t('Explore') }}</a>
-          <a href="https://hive.io" target="_blank">{{ $t('Hive_official') }}</a>
-          <a href="https://hivescan.info" target="_blank">{{ $t('Hive_block_explorer') }}</a>
-          <a href="https://hivescan.info/witnesses" target="_blank">{{ $t('Hive_witnesses') }}</a>
-          <a href="https://hivescan.info/proposals" target="_blank">{{ $t('DHF') }}</a>
+          <a href="https://hive.io" target="_blank" rel="noopener noreferrer">{{ $t('Hive_official') }}</a>
+          <a href="https://hivescan.info" target="_blank" rel="noopener noreferrer">{{ $t('Hive_block_explorer') }}</a>
+          <a href="https://hivescan.info/witnesses" target="_blank" rel="noopener noreferrer">{{ $t('Hive_witnesses') }}</a>
+          <a href="https://hivescan.info/proposals" target="_blank" rel="noopener noreferrer">{{ $t('DHF') }}</a>
         </div>
       </div>
 
       <!-- Social Media Icons -->
       <div class="social-icons-wrapper">
-        <a href="https://links.actifit.io/discord" target="_blank" class="social-icon" :title="$t('Discord')"><i class="fab fa-discord"></i></a>
-        <a href="https://www.facebook.com/Actifit.fitness/" target="_blank" class="social-icon" :title="$t('Facebook')"><i class="fab fa-facebook-f"></i></a>
-        <a href="https://www.x.com/Actifit_fitness" target="_blank" class="social-icon" :title="$t('X_twitter')"><i class="fa-brands fa-square-x-twitter"></i></a>
-        <a href="https://www.instagram.com/actifit.fitness/" target="_blank" class="social-icon" :title="$t('Instagram')"><i class="fab fa-instagram"></i></a>
-        <a href="https://t.me/actifit" target="_blank" class="social-icon" :title="$t('Telegram')"><i class="fab fa-telegram-plane"></i></a>
-        <a href="https://medium.com/@actifit.fitness" target="_blank" class="social-icon" :title="$t('Medium')"><i class="fab fa-medium-m"></i></a>
-        <a href="https://www.youtube.com/Actifitfitness" target="_blank" class="social-icon" :title="$t('Youtube')"><i class="fab fa-youtube"></i></a>
-        <a href="https://www.linkedin.com/company/actifit-io" target="_blank" class="social-icon" :title="$t('LinkedIn')"><i class="fab fa-linkedin-in"></i></a>
-        <a href="https://www.tiktok.com/@actifit" target="_blank" class="social-icon" :title="$t('TikTok')"><i class="fab fa-tiktok"></i></a>
+        <a href="https://links.actifit.io/discord" target="_blank" rel="noopener noreferrer" class="social-icon" :title="$t('Discord')"><i class="fab fa-discord"></i></a>
+        <a href="https://www.facebook.com/Actifit.fitness/" target="_blank" rel="noopener noreferrer" class="social-icon" :title="$t('Facebook')"><i class="fab fa-facebook-f"></i></a>
+        <a href="https://www.x.com/Actifit_fitness" target="_blank" rel="noopener noreferrer" class="social-icon" :title="$t('X_twitter')"><i class="fa-brands fa-square-x-twitter"></i></a>
+        <a href="https://www.instagram.com/actifit.fitness/" target="_blank" rel="noopener noreferrer" class="social-icon" :title="$t('Instagram')"><i class="fab fa-instagram"></i></a>
+        <a href="https://t.me/actifit" target="_blank" rel="noopener noreferrer" class="social-icon" :title="$t('Telegram')"><i class="fab fa-telegram-plane"></i></a>
+        <a href="https://medium.com/@actifit.fitness" target="_blank" rel="noopener noreferrer" class="social-icon" :title="$t('Medium')"><i class="fab fa-medium-m"></i></a>
+        <a href="https://www.youtube.com/Actifitfitness" target="_blank" rel="noopener noreferrer" class="social-icon" :title="$t('Youtube')"><i class="fab fa-youtube"></i></a>
+        <a href="https://www.linkedin.com/company/actifit-io" target="_blank" rel="noopener noreferrer" class="social-icon" :title="$t('LinkedIn')"><i class="fab fa-linkedin-in"></i></a>
+        <a href="https://www.tiktok.com/@actifit" target="_blank" rel="noopener noreferrer" class="social-icon" :title="$t('TikTok')"><i class="fab fa-tiktok"></i></a>
       </div>
 
       <hr class="footer-divider">
@@ -67,7 +67,7 @@
                 Powered By HIVE <img src="/img/HIVE.png" class="hive-logo-bottom">
             </div>
             <div class="bottom-bar-item">
-                Price Data provided By <a href="https://coingecko.com" target="_blank">CoinGecko</a>
+                Price Data provided By <a href="https://coingecko.com" target="_blank" rel="noopener noreferrer">CoinGecko</a>
             </div>
         </div>
         <div class="bottom-row">

--- a/components/News.vue
+++ b/components/News.vue
@@ -1,9 +1,9 @@
-<template>
+﻿<template>
   <div class="news px-3">
     <small>{{ date }}</small>
     <h5>{{ post.title }}</h5>
     <a href="#" class="btn btn-white acti-shadow-inverse" @click="$store.commit('setActiveNews', post)" data-toggle="modal" data-target="#newsModal">{{ $t('Read_more') }}</a>
-	<a :href="'/@'+post.author+'/'+post.permlink" target="_blank" class="btn btn-white float-right acti-shadow-inverse">{{ $t('Full_view') }}</a>
+	<a :href="'/@'+post.author+'/'+post.permlink" target="_blank" rel="noopener noreferrer" class="btn btn-white float-right acti-shadow-inverse">{{ $t('Full_view') }}</a>
   </div>
 </template>
 

--- a/components/PostModal.vue
+++ b/components/PostModal.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div class="modal fade" id="postModal" ref="postModal" tabindex="-1">
     <div class="modal-dialog modal-lg" role="document">
       <div class="modal-content" v-if="post">
@@ -205,7 +205,7 @@
           </small>
           <i class="fas fa-dove"></i>
           <small>
-            <a :href="this.meta.charity[0]" target="_blank">@{{ this.meta.charity[0] }}</a>
+            <a :href="this.meta.charity[0]" target="_blank" rel="noopener noreferrer">@{{ this.meta.charity[0] }}</a>
           </small>
         </div>
         <transition name="fade">

--- a/components/Product.vue
+++ b/components/Product.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <!-- single card item for approved product -->
   <div class="card form mx-auto p-3 mt-3 mt-md-5 text-center pro-card col-sm-4"
     :class="[productTypeBorder, { 'christmas-card': product.specialevent && product.event == 'Christmas' }]">
@@ -366,7 +366,7 @@
       <div v-if="prodHasFriendBenefic()">
         <b>{{ $t('Benef_friend') }}:</b>
         <span v-if="grabConsumableItem().status == 'active'"><i class="fas fa-user-friends pl-2"></i>&nbsp;<a
-            :href="'/' + grabConsumableItem().benefic" target="_blank">{{ grabConsumableItem().benefic }}</a></span>
+            :href="'/' + grabConsumableItem().benefic" target="_blank" rel="noopener noreferrer">{{ grabConsumableItem().benefic }}</a></span>
         <input type="text" name="friend" id="friend" ref="friend" class="form-control p-2" v-else
           :value="grabConsumableItem().benefic">
       </div>

--- a/components/ProfileImageModal.vue
+++ b/components/ProfileImageModal.vue
@@ -170,20 +170,12 @@ export default {
         formData.append('image', renamedFile);
 
         try {
-          const response = await axios.post('https://usermedia.actifit.io/upload', formData, {
-            headers: {
-              'Authorization': process.env.sec_img_upl,
-              'Content-Type': 'multipart/form-data'
-            }
-          });
-          
-          console.log('Upload Success:', response.data);
+          const response = await axios.post('/api/proxy/upload', formData);
           const imageUrl = 'https://usermedia.actifit.io/' + key;
-          console.log(`meow imageurl: ${imageUrl}`)
           return imageUrl;
           
         } catch (error) {
-          console.log('meow Upload Error:', error);
+          console.error('Upload error:', error);
           throw error;
         }
       },

--- a/components/Proposal.vue
+++ b/components/Proposal.vue
@@ -1,14 +1,14 @@
-<template>
+﻿<template>
   <!-- single post item for activity pages -->
   <div >
     <div class="card post" :class="{'card-subscribed':userSubscribed}">
       <!--<h6 class="mb-0 text-center post-title">
 
-		<a :href="buildLink+'/posts'" target="_blank">
+		<a :href="buildLink+'/posts'" target="_blank" rel="noopener noreferrer">
           {{ truncateString(proposal.title, 70) }}
 		  <i class="fas fa-external-link-alt"></i>
         </a>
-      </h6>--><!--<a :href="proposal.url" target="_blank">-->
+      </h6>--><!--<a :href="proposal.url" target="_blank" rel="noopener noreferrer">-->
 
       <div class="post-body" v-if="proposal">
         <div class="row">
@@ -27,7 +27,7 @@
 				</a>
 				</div>
 			</div>
-			<div class="col-4"><a :href="buildLink" target="_blank" class="text-brand">{{proposal.subject}}</a></div>
+			<div class="col-4"><a :href="buildLink" target="_blank" rel="noopener noreferrer" class="text-brand">{{proposal.subject}}</a></div>
 
 		</div>
 		<div class="row">

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <!-- single report item for activity pages -->
   <div>
     <div class="card report">
@@ -107,7 +107,7 @@
           <div class="col-6">
             <i class="fas fa-dove"></i><small> {{ $t('Charity_Post') }} </small><i class="fas fa-dove"></i>
           </div>
-          <div class="col-6 text-right"><small><a :href="this.meta.charity[0]" target="_blank">@{{ this.meta.charity[0] }}</a></small></div>
+          <div class="col-6 text-right"><small><a :href="this.meta.charity[0]" target="_blank" rel="noopener noreferrer">@{{ this.meta.charity[0] }}</a></small></div>
         </div>
         <div class="row details mt-2 text-brand full-afit-txt" v-if="isUserModerator">
           <div class="col-6 text-brand">

--- a/components/ReportModal.vue
+++ b/components/ReportModal.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div class="modal fade" id="reportModal" ref="reportModal" tabindex="-1">
     <div class="modal-dialog modal-lg" role="document">
       <div class="modal-content" v-if="report">
@@ -159,7 +159,7 @@
         <!-- adding section to display charity info if available -->
         <div class="modal-footer text-brand" v-if="this.meta.charity">
           <i class="fas fa-dove"></i><small>{{ $t('Charity_Post') }}</small><i class="fas fa-dove"></i>
-          <small><a :href="this.meta.charity[0]" target="_blank">@{{ this.meta.charity[0] }}</a></small>
+          <small><a :href="this.meta.charity[0]" target="_blank" rel="noopener noreferrer">@{{ this.meta.charity[0] }}</a></small>
         </div>
         <transition name="fade">
           <div class="report-reply modal-body" v-if="commentBoxOpen">

--- a/components/SearchResult.vue
+++ b/components/SearchResult.vue
@@ -1,12 +1,12 @@
-<template>
+﻿<template>
   <div class="search-result card">
     <div class="card-body">
       <h5 class="card-title">
-        <a :href="postLink" target="_blank">{{ post.title }}</a>
+        <a :href="postLink" target="_blank" rel="noopener noreferrer">{{ post.title }}</a>
       </h5>
       <h6 class="card-subtitle mb-2 text-muted">@{{ post.author }}</h6>
       <p class="card-text">{{ truncatedBody }}</p>
-      <a :href="postLink" target="_blank" class="card-link">Read more</a>
+      <a :href="postLink" target="_blank" rel="noopener noreferrer" class="card-link">Read more</a>
     </div>
   </div>
 </template>

--- a/components/StingChat.vue
+++ b/components/StingChat.vue
@@ -59,7 +59,7 @@ export default {
 	  console.log('initwidget');
 	  console.log(window.widget)
 	  if(window.widget != null) return;
-      this.widget = new StWidget('https://chat.peakd.com/t/hive-193552/0');	  
+      this.widget = new StWidget('https://chat.peakd.com/t/hive-193552/0');
 	  this.widget.properties = {
 		"requireLogin": false,
 		"showSidebar": true,
@@ -87,13 +87,13 @@ export default {
 		"--appMessageFontFamily": "''New Heterodox Mono',monospace'",
 		"--appMessageFontSize": "16px"
 		};
-		
+
 		//set user
 		  if (this.user && this.user.account.name){
 			console.log('setting user'+this.user.account.name)
 			this.widget.setUser(this.user.account.name);
 		  }
-	  
+
       // If you would like to not let the widget use keychain passthrough, you can disable it with:
       // stwidget.enableKeychainPassthrough = false;
 	  console.log('init status:'+this.init)
@@ -106,16 +106,16 @@ export default {
 		  this.widget.cleanup();
 		  if (hasChildNodes) return;
 		  console.log('post return');
-		  
+
 		  //check screen dimensions and adjust accordingly if needed
 		  let defaultWidth = 450;
 		  if (screen.width < 750){
 			defaultWidth = screen.width - 40;
 		  }
-		  
+
 		  var element = this.widget.createElement(defaultWidth+'px', '556px', true /* overlay */, true /* resizable */);
 		  this.widget.setStyle({ direction: 'rtl', top: '76px', right: '0px' }); //add custom styles
-		  // Add direction: 'rtl' if you would like the widget to be expandable by dragging the 
+		  // Add direction: 'rtl' if you would like the widget to be expandable by dragging the
 		  // bottom-left corner instead of bottom-right corner
 
 		  //var widgetElement = this.$refs.widget;
@@ -124,11 +124,11 @@ export default {
 			var widgetContainer = this.$refs.widgetContainer;
 			widgetContainer.appendChild(element);
 			widgetContainer.hidden = true;//initialize as hidden
-		  console.log(widgetContainer);
+		  //console.log(widgetContainer);
 		  this.init = false;
 		  //this.widget.pause(true);
-		  
-		  
+
+
 	  }
 
     },

--- a/components/TopHoldersModal.vue
+++ b/components/TopHoldersModal.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div class="modal fade" id="topHoldersModal" ref="topHoldersModal" tabindex="-1">
     <div class="modal-dialog modal-lg" role="document">
       <div class="modal-content">
@@ -21,7 +21,7 @@
 				<tr v-for="(topHolder, key) in holdersList" :key="key" :class="{'bg-danger': user === topHolder.user, 'text-white': user === topHolder.user}">
 				  <td>{{ key + 1 }}</td>
 				  <td>
-					<a :href="topHolder.user" target="_blank" :class="{'text-white': user === topHolder.user}">
+					<a :href="topHolder.user" target="_blank" rel="noopener noreferrer" :class="{'text-white': user === topHolder.user}">
 						@{{ topHolder.user }}
 					</a>
 				  </td>

--- a/components/TopHoldersXModal.vue
+++ b/components/TopHoldersXModal.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div class="modal fade" id="topHoldersXModal" ref="topHoldersXModal" tabindex="-1">
     <div class="modal-dialog modal-lg" role="document">
       <div class="modal-content">
@@ -21,7 +21,7 @@
 				<tr v-for="(topHolder, key) in holdersList" :key="key" :class="{'bg-danger': user === topHolder.account, 'text-white': user === topHolder.account}">
 				  <td>{{ key + 1 }}</td>
 				  <td>
-					<a :href="topHolder.account" target="_blank" :class="{'text-white': user === topHolder.account}">
+					<a :href="topHolder.account" target="_blank" rel="noopener noreferrer" :class="{'text-white': user === topHolder.account}">
 						@{{ topHolder.account }}
 					</a>
 				  </td>

--- a/components/Transaction.vue
+++ b/components/Transaction.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <!-- single transaction item for wallet page -->
   <div class="acti-shadow card p-3 my-2">
     <div class="d-flex flex-row justify-content-between">
@@ -14,8 +14,8 @@
       </div>
     </div>
     <div class="text-center">
-      <a :href="$safeUrl('/@' + transaction.user + '/' + transaction.url)" target="_blank" v-if="transaction.reward_activity == 'Full AFIT Payout'">{{ $t('Activity_Details') }}</a>
-      <a :href="$safeUrl(transaction.url)" target="_blank" v-else-if="transaction.url">{{ $t('Activity_Details') }}</a>
+      <a :href="$safeUrl('/@' + transaction.user + '/' + transaction.url)" target="_blank" rel="noopener noreferrer" v-if="transaction.reward_activity == 'Full AFIT Payout'">{{ $t('Activity_Details') }}</a>
+      <a :href="$safeUrl(transaction.url)" target="_blank" rel="noopener noreferrer" v-else-if="transaction.url">{{ $t('Activity_Details') }}</a>
     </div>
     <p class="font-italic mb-0 mt-2 text-center" v-if="transaction.note">{{ transaction.note }}</p>
   </div>

--- a/components/UserHoverCard.vue
+++ b/components/UserHoverCard.vue
@@ -1,4 +1,4 @@
-
+﻿
 <template>
   <div class="hover-card-container">
     <!-- Display based on mode -->
@@ -15,7 +15,7 @@
 
     <template v-else-if="displayMode === 'no-rank'">
       <span class="user-display d-inline-flex align-items-center"
-         target="_blank"
+         target="_blank" rel="noopener noreferrer"
          @mouseenter="handleMouseEnter"
          @mouseleave="handleMouseLeave">
 				  <div class="user-avatar mr-1" :style="'background-image: url('+profImgUrl+'/u/' + username + '/avatar);'"></div>
@@ -27,7 +27,7 @@
 
     <template v-else-if="displayMode==='username-only'">
       <span class="user-display align-items-center"
-         target="_blank"
+         target="_blank" rel="noopener noreferrer"
          @mouseenter="handleMouseEnter"
          @mouseleave="handleMouseLeave">
 
@@ -40,7 +40,7 @@
 
     <template v-else>
       <span class="user-display d-inline-flex align-items-center"
-         target="_blank"
+         target="_blank" rel="noopener noreferrer"
          @mouseenter="handleMouseEnter"
          @mouseleave="handleMouseLeave">
         <div class="user-avatar mr-1"

--- a/components/UserMenu.vue
+++ b/components/UserMenu.vue
@@ -465,10 +465,13 @@ export default {
 
     async handleNotificationClick(notif) {
       await this.markRead(notif);
-      if (notif.url.startsWith('/')) {
-        this.$router.push(this.localePath(notif.url));
+      const url = notif.url;
+      if (url && url.startsWith('/')) {
+        this.$router.push(this.localePath(url));
+      } else if (url && /^https?:\/\//i.test(url)) {
+        window.location.href = url;
       } else {
-        window.location.href = notif.url;
+        this.$router.push(this.localePath('/notifications'));
       }
     },
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -20,7 +20,7 @@ module.exports = {
 
   // Runtime configuration
   publicRuntimeConfig: {
-    version: '1.10.0',
+    version: pkg.version,
     proposalId: '360',
   },
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -381,22 +381,19 @@ module.exports = {
     "defaults"
   },*/
 
-  /*helmet: {
-
-    dnsPrefetchControl: false,
-    expectCt: false,
-    featurePolicy: false,
+  helmet: {
+    // frameguard disabled — X-Frame-Options: ALLOWALL is set explicitly in render.static
     frameguard: false,
-    hidePoweredBy: false,
-    hsts: false,
-    ieNoOpen: false,
-    noCache: false,
-    noSniff: false,
+    dnsPrefetchControl: { allow: false },
+    hidePoweredBy: true,
+    hsts: { maxAge: 15552000, includeSubDomains: true, preload: false },
+    ieNoOpen: true,
+    noSniff: true,
+    referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+    xssFilter: true,
+    expectCt: false,
     permittedCrossDomainPolicies: false,
-    referrerPolicy: false,
-    xssFilter: false,
-
- },*/
+  },
   /*
   ** Build configuration
   */
@@ -429,7 +426,15 @@ module.exports = {
       }
     },
     //fixes issue with hive-auth-wrapper plugin integration
-    transpile: ['hive-auth-wrapper', 'dompurify']
+    transpile: ['hive-auth-wrapper', 'dompurify'],
+
+    terser: {
+      terserOptions: {
+        compress: {
+          drop_console: true
+        }
+      }
+    }
 
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.9.0",
+  "version": "1.10.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actifit-landingpage",
-      "version": "1.9.0",
+      "version": "1.10.1",
       "hasInstallScript": true,
       "dependencies": {
         "@blurtfoundation/blurtjs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Actifit is an innovative dapp that aims to incentivize fitness and healthy lifestyle via rewarding daily activity.",
   "author": "mktcode",
   "private": true,

--- a/pages/_username/_permlink/index.vue
+++ b/pages/_username/_permlink/index.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div>
     <NavbarBrand />
 
@@ -151,7 +151,7 @@
               </div>
               <div class="modal-footer col-md-12 text-brand" v-if="meta.charity">
                 <i class="fas fa-dove"></i><small> {{ $t('Charity_Post') }} </small><i class="fas fa-dove"></i>
-                <small><a :href="meta.charity[0]" target="_blank">@{{ meta.charity[0] }}</a></small>
+                <small><a :href="meta.charity[0]" target="_blank" rel="noopener noreferrer">@{{ meta.charity[0] }}</a></small>
               </div>
               <transition name="fade">
                 <div class="report-reply col-md-12" v-if="commentBoxOpen">
@@ -168,7 +168,7 @@
                 </div>
               </transition>
               <div class="report-reply col-md-12" v-if="responsePosted">
-                <a target="_blank"><div class="comment-user-section"><UserHoverCard :username="user.account.name" /></div></a>
+                <a target="_blank" rel="noopener noreferrer"><div class="comment-user-section"><UserHoverCard :username="user.account.name" /></div></a>
                 <SafeRemarkable :source="responseBody" :options="{ 'html': true, 'breaks': true, 'typographer': true }"></SafeRemarkable>
               </div>
 

--- a/pages/_username/index.vue
+++ b/pages/_username/index.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div>
     <NavbarBrand />
     <div v-if="loadingData" class="container pt-5 mt-5 pb-5">
@@ -123,7 +123,7 @@
                      <div v-if="updatingField === 'link'" class="d-flex justify-content-end align-items-center h-100 w-100"><i class="fas fa-spinner fa-spin text-brand"></i></div>
                      <template v-else>
                         <div class="about-item-text" v-if="!linkEditOn">
-                          <a v-if="userMeta && userMeta.profile && userMeta.profile.website" :href="$safeUrl(userMeta.profile.website)" target="_blank">{{ textAreaLinkValue }}</a>
+                          <a v-if="userMeta && userMeta.profile && userMeta.profile.website" :href="$safeUrl(userMeta.profile.website)" target="_blank" rel="noopener noreferrer">{{ textAreaLinkValue }}</a>
                           <span v-else>{{ textAreaLinkValue || $t('Not_Set') }}</span>
                         </div>
                         <div class="about-item-edit" v-else>
@@ -206,7 +206,7 @@
                     </span>
                      <div v-html="$t('posh_desc_profile')"></div>
                   </div>
-                  <a v-if="!poshVerified" class="btn btn-danger m-2" href="https://hiveposh.com/" target="_blank">{{ $t('Posh_verify') }}</a>
+                  <a v-if="!poshVerified" class="btn btn-danger m-2" href="https://hiveposh.com/" target="_blank" rel="noopener noreferrer">{{ $t('Posh_verify') }}</a>
                 </div>
               </div>
               <!-- Key added -->
@@ -254,7 +254,7 @@
 
                       <a href="#" data-toggle="modal" data-target="#notifyModal" class="text-danger"><i class="fas fa-info-circle" :title="$t('view_details')"></i></a>
                    </div>
-                  <a href="https://splinterlands.com/" target="_blank" class="btn btn-danger m-2">{{ $t('Play_splinterlands') }}</a>
+                  <a href="https://splinterlands.com/" target="_blank" rel="noopener noreferrer" class="btn btn-danger m-2">{{ $t('Play_splinterlands') }}</a>
                 </div>
               </div>
               <!-- Key added -->
@@ -293,7 +293,7 @@
                       <div v-if="actifitDelegator" class="text-dark">
                         <i class="fas fa-check text-success mr-2"></i>{{ $t('Delegates_to_Actifit') }} ({{ actifitDelegator.steem_power }} {{ $t('Hive_Power') }})
                       </div>
-                       <a class="btn btn-danger m-2" href="/wallet" target="_blank">{{ $t('Delegate_Now_Actifit') }}</a>
+                       <a class="btn btn-danger m-2" href="/wallet" target="_blank" rel="noopener noreferrer">{{ $t('Delegate_Now_Actifit') }}</a>
                     </div>
                  </div>
 
@@ -397,7 +397,7 @@
                     <div class="form-group">
                       <label for="funds-pass">{{ $t('Funds_Password') }}</label>
                       <input type="password" id="funds-pass" name="funds-pass" ref="funds-pass" class="form-control">
-                      <small><a href="/wallet?action=set_funds_pass" target="_blank">{{ $t('create_pass_short') }}</a></small>
+                      <small><a href="/wallet?action=set_funds_pass" target="_blank" rel="noopener noreferrer">{{ $t('create_pass_short') }}</a></small>
                     </div>
                     <div v-if="tipError" v-html="tipError" class="alert alert-danger"></div>
                     <div>

--- a/pages/_username/videos/index.vue
+++ b/pages/_username/videos/index.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <!-- videos listing for single user -->
   <div>
     <NavbarBrand />
@@ -15,7 +15,7 @@
       </div>
 
 	  <div class="text-center p-3" v-else-if="user">
-		<a :href="'/videos/new'" :title="$t('Create_Video')" target="_blank" class="btn btn-brand border">
+		<a :href="'/videos/new'" :title="$t('Create_Video')" target="_blank" rel="noopener noreferrer" class="btn btn-brand border">
 			{{ $t('Create_Video') }}
 		</a>
 	  </div>

--- a/pages/_username/videos/new.vue
+++ b/pages/_username/videos/new.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div>
     <NavbarBrand />
     <div class="container pt-5 mt-5 pb-5">
@@ -81,7 +81,7 @@
             class="btn btn-white border text-red acti-shadow" @click="video = markVideoPublished(video)">Mark published
             <i v-if="marking == video._id" class="fas fa-spin fa-spinner text-brand"></i></button>
           <a v-else class="btn btn-white border text-red acti-shadow float-right"
-            :href="'/' + video.owner + '/' + video.permlink" target="_blank">View Post</a>
+            :href="'/' + video.owner + '/' + video.permlink" target="_blank" rel="noopener noreferrer">View Post</a>
           <!--<div v-if="selVid == video">Selected</div>-->
         </div>
       </div>

--- a/pages/_username/wallet.vue
+++ b/pages/_username/wallet.vue
@@ -1889,12 +1889,7 @@ import VueScrollTo from 'vue-scrollto' // for smooth scrolling
 
 import GenericTopHoldersModal from '@/components/GenericTopHoldersModal.vue';
 
-//Disable: EOL for S-E
-//const ssc = new SSC(process.env.steemEngineRpc);
-const scot_steemengine_api = process.env.steemEngineScot;
-
 const hsc = new SSC(process.env.hiveEngineRpc);
-const scot_hive_api_param = process.env.hiveEngineScotParam;
 
 const tokensNonStakable = ['AFITX', 'AFIT', 'SWAP.HIVE', 'SWAP.BLURT'];
 const tokensOfInterest = ['SPORTS', 'PAL', 'APX', 'BEE', 'POSH', 'LEO'].concat(tokensNonStakable);
@@ -3774,14 +3769,16 @@ export default {
     },
 
     setAFITPrice(_afitPrice) {
-      this.afitPrice = parseFloat(_afitPrice).toFixed(6);
+      const p = parseFloat(_afitPrice);
+      if (!isNaN(p)) this.afitPrice = p;
     },
     setAFITBSCPrice(_afitPrice) {
-      this.afitBSCPrice = parseFloat(_afitPrice).toFixed(6);
-      console.log('afitBSCPrice' + this.afitBSCPrice);
+      const p = parseFloat(_afitPrice);
+      if (!isNaN(p)) this.afitBSCPrice = p;
     },
     setAFITXBSCPrice(_afitxPrice) {
-      this.afitxBSCPrice = parseFloat(_afitxPrice).toFixed(6);
+      const p = parseFloat(_afitxPrice);
+      if (!isNaN(p)) this.afitxBSCPrice = p;
       console.log('afitxBSCPrice' + this.afitxBSCPrice);
     },
     setUserPassStatus(result) {
@@ -3853,22 +3850,6 @@ export default {
         let prec = this.tokenOfInterestPrecision[symbol];
         return this.numberFormat(amount / Math.pow(10, prec), prec)
       }
-    },
-    setSETokensPrecision(result) {
-      let par = this;
-      this.tokenOfInterestPrecision = [];
-      //console.log(result);
-      //loop through our tokens of interest to fetch them and allow users to claim their rewards
-      tokensOfInterest.forEach(function (item, index) {
-        try {
-          let tokenDetails = result[item];
-          if (tokenDetails) {
-            par.tokenOfInterestPrecision[item] = tokenDetails.precision;
-          }
-        } catch (e) {
-          console.error(e);
-        }
-      });
     },
     setUserSettings(result) {
       //console.log('fetched user settings');
@@ -4136,20 +4117,18 @@ export default {
     },
     async fetchTokenBalance() {
       try {
-        if (this.cur_bchain == 'HIVE') {
-          try {
-            const response = await fetch(scot_steemengine_api + 'info' + scot_hive_api_param);
-            const json = await response.json();
-            if (json) {
-              this.setSETokensPrecision(json);
-            }
-          } catch (e) {
-            console.log('Error fetching token precisions:', e);
-          }
-        }
-
         const tokenData = await hsc.find('tokens', 'balances', { account: this.displayUserData.name });
         const tokenExtraDetails = await hsc.find('tokens', 'tokens', {});
+
+        if (this.cur_bchain == 'HIVE' && Array.isArray(tokenExtraDetails)) {
+          this.tokenOfInterestPrecision = [];
+          tokensOfInterest.forEach(symbol => {
+            const entry = tokenExtraDetails.find(v => v.symbol === symbol);
+            if (entry && entry.precision != null) {
+              this.tokenOfInterestPrecision[symbol] = entry.precision;
+            }
+          });
+        }
 
         if (Array.isArray(tokenData)) {
           tokenData.forEach(token => {
@@ -8085,20 +8064,24 @@ export default {
       return parseFloat(this.afitBuyAmount * this.afitPrice / this.steemPrice).toFixed(3);
     },
     setSteemPrice(_steemPrice) {
-
-      this.steemPrice = parseFloat(_steemPrice).toFixed(3);
+      const p = parseFloat(_steemPrice);
+      if (!isNaN(p)) this.steemPrice = p;
     },
     setSBDPrice(_sbdPrice) {
-      this.sbdPrice = parseFloat(_sbdPrice).toFixed(3);
+      const p = parseFloat(_sbdPrice);
+      if (!isNaN(p)) this.sbdPrice = p;
     },
     setHivePrice(_hivePrice) {
-      this.hivePrice = parseFloat(_hivePrice).toFixed(3);
+      const p = parseFloat(_hivePrice);
+      if (!isNaN(p)) this.hivePrice = p;
     },
     setHBDPrice(_hbdPrice) {
-      this.hbdPrice = parseFloat(_hbdPrice).toFixed(3);
+      const p = parseFloat(_hbdPrice);
+      if (!isNaN(p)) this.hbdPrice = p;
     },
     setBlurtPrice(_blurtPrice) {
-      this.blurtPrice = parseFloat(_blurtPrice).toFixed(3);
+      const p = parseFloat(_blurtPrice);
+      if (!isNaN(p)) this.blurtPrice = p;
     },
     async loadGlobalProperties() {
       try {

--- a/pages/_username/wallet.vue
+++ b/pages/_username/wallet.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div>
     <NavbarBrand @user-switched="refreshAllWalletData" />
 
@@ -123,8 +123,7 @@
               <a v-if="cur_bchain == 'STEEM'" href="https://steem-engine.net/?p=market&t=AFIT"
                 :class="smallScreenBtnClasses" target="_blank" rel="noopener noreferrer" :text="$t('buy_afit_se')"><span
                   class="btn btn-brand p-1" :title="$t('buy_afit_he')">$</span></a>
-              <a v-else href="https://hive-engine.com/?p=market&t=AFIT" :class="smallScreenBtnClasses" target="_blank"
-                rel="noopener noreferrer"><span class="btn btn-brand p-1" :title="$t('buy_afit_he')">$</span></a>
+              <a v-else href="https://hive-engine.com/?p=market&t=AFIT" :class="smallScreenBtnClasses" target="_blank" rel="noopener noreferrer"><span class="btn btn-brand p-1" :title="$t('buy_afit_he')">$</span></a>
 
               <span class="btn btn-brand p-1" :title="$t('EXCHANGE_AFIT_FOR_STEEM')" v-on:click="exchangeAFITforSTEEM">
                 <i class="fas fa-solid fa-thumbs-up"></i>
@@ -393,11 +392,11 @@
             <div class="col-1 col-lg-2 text-right break-val">{{ formattedUserAfitBSCVal }}</div>
             <div class="col-lg-2 col-1 token_actions">
               <span class="btn btn-brand p-1" :title="$t('smart_contract')">
-                <a target="_blank" :href="'https://bscscan.com/address/' + afitTokenAddress"><i
+                <a target="_blank" rel="noopener noreferrer" :href="'https://bscscan.com/address/' + afitTokenAddress"><i
                     class="fas fa-file-contract"></i></a>
               </span>
               <a href="https://defi.actifit.io/swap?outputCurrency=0x4516bb582f59befcbc945d8c2dac63ef21fba9f6"
-                :class="smallScreenBtnClasses" target="_blank"><span class="btn btn-brand p-1"
+                :class="smallScreenBtnClasses" target="_blank" rel="noopener noreferrer"><span class="btn btn-brand p-1"
                   :title="$t('buy_afit_bsc')">
                   $
                 </span></a>
@@ -413,7 +412,7 @@
             <div class="col-1 col-lg-2 text-right">-</div>
             <div class="col-lg-2 col-1 token_actions">
               <span class="btn btn-brand p-1" :title="$t('smart_contract')">
-                <a target="_blank" :href="'https://bscscan.com/address/' + afitBNBLPTokenAddress"><i
+                <a target="_blank" rel="noopener noreferrer" :href="'https://bscscan.com/address/' + afitBNBLPTokenAddress"><i
                     class="fas fa-file-contract"></i></a>
               </span>
             </div>
@@ -429,11 +428,11 @@
             <div class="col-1 col-lg-2 text-right break-val">{{ formattedUserAfitxBSCVal }}</div>
             <div class="col-lg-2 col-1 token_actions">
               <span class="btn btn-brand p-1" :title="$t('smart_contract')">
-                <a target="_blank" :href="'https://bscscan.com/address/' + afitxTokenAddress"><i
+                <a target="_blank" rel="noopener noreferrer" :href="'https://bscscan.com/address/' + afitxTokenAddress"><i
                     class="fas fa-file-contract"></i></a>
               </span>
               <a href="https://defi.actifit.io/swap?outputCurrency=0x246d22ff6e0b90f80f2278613e8db93ff7a09b95"
-                :class="smallScreenBtnClasses" target="_blank"><span class="btn btn-brand p-1"
+                :class="smallScreenBtnClasses" target="_blank" rel="noopener noreferrer"><span class="btn btn-brand p-1"
                   :title="$t('buy_afitx_bsc')">
                   $
                 </span></a>
@@ -449,7 +448,7 @@
             <div class="col-1 col-lg-2 text-right">-</div>
             <div class="col-lg-2 col-1 token_actions">
               <span class="btn btn-brand p-1" :title="$t('smart_contract')">
-                <a target="_blank" :href="'https://bscscan.com/address/' + afitxBNBLPTokenAddress"><i
+                <a target="_blank" rel="noopener noreferrer" :href="'https://bscscan.com/address/' + afitxBNBLPTokenAddress"><i
                     class="fas fa-file-contract"></i></a>
               </span>
             </div>
@@ -494,8 +493,7 @@
 
                 <span v-if="token.symbol == 'AFITX'" class="btn btn-brand p-1">
                   <a v-if="cur_bchain == 'STEEM'" :title="$t('buy_afitx_se')"
-                    href="https://steem-engine.net/?p=market&t=AFITX" class="" target="_blank"
-                    rel="noopener noreferrer">$</a>
+                    href="https://steem-engine.net/?p=market&t=AFITX" class="" target="_blank" rel="noopener noreferrer">$</a>
                   <a v-else :title="$t('buy_afitx_he')" href="https://hive-engine.com/?p=market&t=AFITX" class=""
                     target="_blank" rel="noopener noreferrer">$</a>
                 </span>
@@ -509,8 +507,8 @@
 
 
                 <span v-if="token.symbol == 'AFIT'" class="btn btn-brand p-1" :title="$t('buy_afit_he')">
-                  <a v-if="cur_bchain == 'STEEM'" href="https://steem-engine.net/?p=market&t=AFIT" target="_blank"
-                    rel="noopener noreferrer" :text="$t('buy_afit_se')">$</a>
+                  <a v-if="cur_bchain == 'STEEM'" href="https://steem-engine.net/?p=market&t=AFIT" target="_blank" rel="noopener noreferrer"
+                    :text="$t('buy_afit_se')">$</a>
                   <a v-else href="https://hive-engine.com/?p=market&t=AFIT" target="_blank" rel="noopener noreferrer"
                     :text="$t('buy_afit_he')">$</a>
                 </span>
@@ -1373,7 +1371,7 @@
                     <label for="funds-pass" class="w-25 p-2">{{ $t('Funds_Password') }}</label>
                     <input type="password" id="funds-pass" name="funds-pass" ref="funds-pass"
                       class="form-control-lg w-50 p-2">
-                    <a href="/wallet?action=set_funds_pass" target="_blank" class="btn btn-brand border m-1">{{
+                    <a href="/wallet?action=set_funds_pass" target="_blank" rel="noopener noreferrer" class="btn btn-brand border m-1">{{
                       $t('create_pass_short') }}</a>
                   </div>
                   <div class="row">
@@ -1418,7 +1416,7 @@
                     <label for="move-funds-pass" class="w-25 p-2 text-right">{{ $t('Funds_Password') }}</label>
                     <input type="password" id="move-funds-pass" name="move-funds-pass" ref="move-funds-pass"
                       class="form-control-lg w-50 p-2">
-                    <a href="/wallet?action=set_funds_pass" target="_blank" class="btn btn-brand border m-1">{{
+                    <a href="/wallet?action=set_funds_pass" target="_blank" rel="noopener noreferrer" class="btn btn-brand border m-1">{{
                       $t('create_pass_short') }}</a>
                   </div>
                   <div class="text-brand text-center" v-if="afit_se_move_error_proceeding"

--- a/pages/delegators.vue
+++ b/pages/delegators.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <!-- delegators listing -->
   <div>
     <NavbarBrand />
@@ -12,11 +12,11 @@
 	  <h3 class="text-center text-brand mb-5"><img src="/img/HIVE.png" style="max-height: 50px;">{{ $t('Hive_Power_Delegators') }}</h3>
       <div class="row" v-if="topDelegators.hive && topDelegators.hive.length">
           <div class="col-6 col-sm-4 col-md-3 text-center mb-4" v-for="(delegator, index) in topDelegators.hive" :key="index" :delegator="delegator">
-            <a :href="delegator._id" target="_blank">
+            <a :href="delegator._id" target="_blank" rel="noopener noreferrer">
               <div class="avatar small mx-auto mb-3" :style="'background-image: url('+profImgUrl+'/u/' + delegator._id + '/avatar);'"></div>
             </a>
-            <a :href="delegator._id" target="_blank">@{{ delegator._id }}</a><br/>
-			<img src="/img/HIVE.png" style="max-height: 20px;"><a :href="delegator._id" target="_blank">{{ numberFormat(delegator.steem_power, 0) }} {{ $t('Hive_Power') }}</a>
+            <a :href="delegator._id" target="_blank" rel="noopener noreferrer">@{{ delegator._id }}</a><br/>
+			<img src="/img/HIVE.png" style="max-height: 20px;"><a :href="delegator._id" target="_blank" rel="noopener noreferrer">{{ numberFormat(delegator.steem_power, 0) }} {{ $t('Hive_Power') }}</a>
           </div>
       </div>
     </div>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div class="home" ref="homePage">
     <!-- top anchor -->
     <a id="top"></a>
@@ -80,7 +80,7 @@
                       <div v-for="(report, index) in fullReports" :key="'activity-' + index" class="activity-card-scroller-item">
                           <div class="activity-post-card h-100" :style="getCardBackground(report)">
                               <!-- The content container is now the link, making the whole card clickable -->
-                              <a :href="$safeUrl(report.url)" target="_blank" class="activity-card-content" :title="report.title || 'View Post'">
+                              <a :href="$safeUrl(report.url)" target="_blank" rel="noopener noreferrer" class="activity-card-content" :title="report.title || 'View Post'">
                                   <div class="card-user-info">
                                       <div class="avatar small" :style="'background-image: url(' + profImgUrl + '/u/' + report.author + '/avatar);'"></div>
                                       <span class="username">@{{ report.author }}</span>
@@ -148,10 +148,10 @@
             <p class="lead mb-4" v-html="$t('homepage.section2_desc')"></p>
             <p class="download-bonus-text">{{ $t('homepage.download_bonus') }}</p>
             <div class="app-buttons-container">
-              <a href="https://links.actifit.io/android" target="_blank">
+              <a href="https://links.actifit.io/android" target="_blank" rel="noopener noreferrer">
                 <img src="/img/google-play.png" :alt="$t('alt_texts.google_play')">
               </a>
-              <a href="https://links.actifit.io/ios" target="_blank">
+              <a href="https://links.actifit.io/ios" target="_blank" rel="noopener noreferrer">
                 <img src="/img/app-store.png" :alt="$t('alt_texts.app_store')">
               </a>
             </div>
@@ -174,11 +174,11 @@
 
               <h4 class="mt-4 mb-3">{{ $t('available_on') }}</h4>
               <div class="exchange-tags-container">
-                  <a href="https://tribaldex.com/trade/AFIT" class="exchange-tag" target="_blank"><i class="fas fa-coins mr-2"></i>{{ $t('exchanges.hive_engine') }}</a>
-                  <a href="https://defi.actifit.io/swap?outputCurrency=0x4516bb582f59befcbc945d8c2dac63ef21fba9f6" target="_blank" class="exchange-tag"><i class="fas fa-fire-alt mr-2"></i>{{ $t('exchanges.actifit_defi') }}</a>
-                  <a href="https://pancakeswap.finance/swap?outputCurrency=0x4516bb582f59befcbc945d8c2dac63ef21fba9f6" target="_blank" class="exchange-tag"><i class="fas fa-sync-alt mr-2"></i>{{ $t('exchanges.pancakeswap') }}</a>
-                  <a href="https://www.digifinex.com/en-ww/trade/USDT/AFIT" target="_blank" class="exchange-tag"><i class="fas fa-chart-line mr-2"></i>{{ $t('exchanges.digifinex') }}</a>
-                  <a href="https://dex-trade.com/spot/trading/AFITUSDT" target="_blank" class="exchange-tag"><i class="fas fa-exchange-alt mr-2"></i>{{ $t('exchanges.dex_trade') }}</a>
+                  <a href="https://tribaldex.com/trade/AFIT" class="exchange-tag" target="_blank" rel="noopener noreferrer"><i class="fas fa-coins mr-2"></i>{{ $t('exchanges.hive_engine') }}</a>
+                  <a href="https://defi.actifit.io/swap?outputCurrency=0x4516bb582f59befcbc945d8c2dac63ef21fba9f6" target="_blank" rel="noopener noreferrer" class="exchange-tag"><i class="fas fa-fire-alt mr-2"></i>{{ $t('exchanges.actifit_defi') }}</a>
+                  <a href="https://pancakeswap.finance/swap?outputCurrency=0x4516bb582f59befcbc945d8c2dac63ef21fba9f6" target="_blank" rel="noopener noreferrer" class="exchange-tag"><i class="fas fa-sync-alt mr-2"></i>{{ $t('exchanges.pancakeswap') }}</a>
+                  <a href="https://www.digifinex.com/en-ww/trade/USDT/AFIT" target="_blank" rel="noopener noreferrer" class="exchange-tag"><i class="fas fa-chart-line mr-2"></i>{{ $t('exchanges.digifinex') }}</a>
+                  <a href="https://dex-trade.com/spot/trading/AFITUSDT" target="_blank" rel="noopener noreferrer" class="exchange-tag"><i class="fas fa-exchange-alt mr-2"></i>{{ $t('exchanges.dex_trade') }}</a>
               </div>
           </div>
         </div>
@@ -219,14 +219,14 @@
               <div class="custom-scroller-inner">
                 <div v-for="(delegator, index) in enrichedDelegators" :key="'hive' + index" class="delegator-card">
                     <div class="card-header">
-                      <a :href="'https://ecency.com/@' + delegator._id" target="_blank" class="delegator-avatar-link">
+                      <a :href="'https://ecency.com/@' + delegator._id" target="_blank" rel="noopener noreferrer" class="delegator-avatar-link">
                           <div class="avatar-glow"></div>
                           <div class="avatar large" :style="'background-image: url(' + profImgUrl + '/u/' + delegator._id + '/avatar);'"></div>
                       </a>
-                      <a :href="'https://ecency.com/@' + delegator._id" target="_blank" class="username">@{{ delegator._id }}</a>
+                      <a :href="'https://ecency.com/@' + delegator._id" target="_blank" rel="noopener noreferrer" class="username">@{{ delegator._id }}</a>
                     </div>
                     <div class="card-body">
-                        <a :href="'https://ecency.com/@' + delegator._id + '/wallet'" target="_blank" class="stat-row">
+                        <a :href="'https://ecency.com/@' + delegator._id + '/wallet'" target="_blank" rel="noopener noreferrer" class="stat-row">
                             <i class="fas fa-power-off text-brand"></i>
                             <span>{{ numberFormat(delegator.steem_power, 0) }} {{ $t('HP_short') }}</span>
                         </a>
@@ -274,20 +274,20 @@
           <!-- 1st Place Column (now first in HTML) -->
           <div class="podium-column is-first">
             <img src="/img/1st_place_medal.svg" class="medal-icon" :alt="$t('alt_texts.gold_medal')">
-            <a v-if="leaderboardPosts[0] && leaderboardPosts[0].imageUrl" :href="leaderboardPosts[0].postUrl" target="_blank" class="podium-post-link">
+            <a v-if="leaderboardPosts[0] && leaderboardPosts[0].imageUrl" :href="leaderboardPosts[0].postUrl" target="_blank" rel="noopener noreferrer" class="podium-post-link">
               <div class="podium-post-image" :style="{ backgroundImage: 'url(' + leaderboardPosts[0].imageUrl + ')' }"></div>
             </a>
             <div v-else class="podium-post-image-placeholder"></div>
 
             <div class="user-details">
-              <a :href="'/activity/' + leaderboard[0].username.replace('@', '')" target="_blank">
+              <a :href="'/activity/' + leaderboard[0].username.replace('@', '')" target="_blank" rel="noopener noreferrer">
                 <div class="avatar"
                   :style="'background-image: url(' + profImgUrl + '/u/' + leaderboard[0].username.replace('@', '') + '/avatar);'">
                 </div>
               </a>
-              <a class="username" :href="'/activity/' + leaderboard[0].username.replace('@', '')" target="_blank">{{
+              <a class="username" :href="'/activity/' + leaderboard[0].username.replace('@', '')" target="_blank" rel="noopener noreferrer">{{
                 leaderboard[0].username.replace('@','') }}</a>
-              <a :href="leaderboardPosts[0] ? leaderboardPosts[0].postUrl : '#'" target="_blank" class="activity-count">{{ leaderboard[0].activity_count }} {{ $t('Recorded_Activity') }}</a>
+              <a :href="leaderboardPosts[0] ? leaderboardPosts[0].postUrl : '#'" target="_blank" rel="noopener noreferrer" class="activity-count">{{ leaderboard[0].activity_count }} {{ $t('Recorded_Activity') }}</a>
             </div>
             <div class="podium-base gold">
               <span class="rank-number">1</span>
@@ -296,20 +296,20 @@
 
           <!-- 2nd Place Column (now second in HTML) -->
           <div class="podium-column is-second">
-            <a v-if="leaderboardPosts[1] && leaderboardPosts[1].imageUrl" :href="leaderboardPosts[1].postUrl" target="_blank" class="podium-post-link">
+            <a v-if="leaderboardPosts[1] && leaderboardPosts[1].imageUrl" :href="leaderboardPosts[1].postUrl" target="_blank" rel="noopener noreferrer" class="podium-post-link">
               <div class="podium-post-image" :style="{ backgroundImage: 'url(' + leaderboardPosts[1].imageUrl + ')' }"></div>
             </a>
             <div v-else class="podium-post-image-placeholder"></div>
 
             <div class="user-details">
-              <a :href="'/activity/' + leaderboard[1].username.replace('@', '')" target="_blank">
+              <a :href="'/activity/' + leaderboard[1].username.replace('@', '')" target="_blank" rel="noopener noreferrer">
                 <div class="avatar"
                   :style="'background-image: url(' + profImgUrl + '/u/' + leaderboard[1].username.replace('@', '') + '/avatar);'">
                 </div>
               </a>
-              <a class="username" :href="'/activity/' + leaderboard[1].username.replace('@', '')" target="_blank">{{
+              <a class="username" :href="'/activity/' + leaderboard[1].username.replace('@', '')" target="_blank" rel="noopener noreferrer">{{
                 leaderboard[1].username.replace('@','') }}</a>
-              <a :href="leaderboardPosts[1] ? leaderboardPosts[1].postUrl : '#'" target="_blank" class="activity-count">{{ leaderboard[1].activity_count }} {{ $t('Recorded_Activity') }}</a>
+              <a :href="leaderboardPosts[1] ? leaderboardPosts[1].postUrl : '#'" target="_blank" rel="noopener noreferrer" class="activity-count">{{ leaderboard[1].activity_count }} {{ $t('Recorded_Activity') }}</a>
             </div>
             <div class="podium-base silver">
               <span class="rank-number">2</span>
@@ -318,20 +318,20 @@
 
           <!-- 3rd Place Column (now third in HTML) -->
           <div class="podium-column is-third">
-            <a v-if="leaderboardPosts[2] && leaderboardPosts[2].imageUrl" :href="leaderboardPosts[2].postUrl" target="_blank" class="podium-post-link">
+            <a v-if="leaderboardPosts[2] && leaderboardPosts[2].imageUrl" :href="leaderboardPosts[2].postUrl" target="_blank" rel="noopener noreferrer" class="podium-post-link">
               <div class="podium-post-image" :style="{ backgroundImage: 'url(' + leaderboardPosts[2].imageUrl + ')' }"></div>
             </a>
             <div v-else class="podium-post-image-placeholder"></div>
 
             <div class="user-details">
-              <a :href="'/activity/' + leaderboard[2].username.replace('@', '')" target="_blank">
+              <a :href="'/activity/' + leaderboard[2].username.replace('@', '')" target="_blank" rel="noopener noreferrer">
                 <div class="avatar"
                   :style="'background-image: url(' + profImgUrl + '/u/' + leaderboard[2].username.replace('@', '') + '/avatar);'">
                 </div>
               </a>
-              <a class="username" :href="'/activity/' + leaderboard[2].username.replace('@', '')" target="_blank">{{
+              <a class="username" :href="'/activity/' + leaderboard[2].username.replace('@', '')" target="_blank" rel="noopener noreferrer">{{
                 leaderboard[2].username.replace('@','') }}</a>
-              <a :href="leaderboardPosts[2] ? leaderboardPosts[2].postUrl : '#'" target="_blank" class="activity-count">{{ leaderboard[2].activity_count }} {{ $t('Recorded_Activity') }}</a>
+              <a :href="leaderboardPosts[2] ? leaderboardPosts[2].postUrl : '#'" target="_blank" rel="noopener noreferrer" class="activity-count">{{ leaderboard[2].activity_count }} {{ $t('Recorded_Activity') }}</a>
             </div>
             <div class="podium-base bronze">
               <span class="rank-number">3</span>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -788,7 +788,7 @@ export default {
     },
     async setPendingRewards(json) {
       this.pendingRewards = json;
-      if (this.pendingRewards.pendingRewards.HIVE.amount || this.pendingRewards.pendingRewards.STEEM.amount || this.pendingRewards.pendingRewards.BLURT.amount) {
+      if (this.pendingRewards.pendingRewards?.HIVE?.amount || this.pendingRewards.pendingRewards?.STEEM?.amount || this.pendingRewards.pendingRewards?.BLURT?.amount) {
         if (!localStorage.getItem('preventRewardsPop')) {
           this.$refs['pendingRewardsKicker'].click();
         }

--- a/pages/leaderboard.vue
+++ b/pages/leaderboard.vue
@@ -1,4 +1,4 @@
-<template>
+﻿<template>
   <div>
 	<NavbarBrand />
 
@@ -6,7 +6,7 @@
     <ListHeadingSection :textualDisplay="$t('Daily_Leaderboard')" />
 		<div v-if="!Array.isArray(extLeaderboard) || extLeaderboard.length < 3" class="md-col-12 text-center"><i class="fas fa-spin fa-spinner text-brand"></i></div>
 		<div v-else>
-			<div v-if="user" class="text-right"><button target="_blank" class="btn btn-lg btn-brand btn-group-vertical" v-on:click="findUser">{{ $t('Find_me') }}</button></div>
+			<div v-if="user" class="text-right"><button target="_blank" rel="noopener noreferrer" class="btn btn-lg btn-brand btn-group-vertical" v-on:click="findUser">{{ $t('Find_me') }}</button></div>
 		</div>
 		<div v-if="extLeaderboard.length >= 3" class="col-12">
     <div class="row border-actifit" v-for="(curEntry, index) in extLeaderboard" :key="index" :class="entryRelClass(curEntry.author, curEntry.activityCount[0])" :ref="curEntry.author">
@@ -14,12 +14,12 @@
               <span class="avatar pro-card-av rank-class" style="background-image: url(img/gadgets/friend-ranker.png);" >
 				<div class="p-3">{{index+1}}</div>
 			  </span>
-              <a :href="curEntry.author" target="_blank">
+              <a :href="curEntry.author" target="_blank" rel="noopener noreferrer">
                 <div class="avatar mb-3 " :style="'background-image: url('+profImgUrl+'/u/' + curEntry.author.replace('@','') + '/avatar);'"></div>
               </a>
-              <a :href="curEntry.author" target="_blank" class="col-md-3 mt-3"><span>@{{ curEntry.author }}</span></a><br/>
-			  <a :href="curEntry.author" target="_blank" class="col-md-3 mt-3"><span>{{ numberFormat(curEntry.activityCount[0], 0) }} {{$t('Recorded_Activity')}}</span></a>
-			  <div><a :href="$safeUrl(curEntry.url)" target="_blank" class="btn btn-lg btn-brand btn-group-vertical">{{ $t('View_post_details') }}</a></div>
+              <a :href="curEntry.author" target="_blank" rel="noopener noreferrer" class="col-md-3 mt-3"><span>@{{ curEntry.author }}</span></a><br/>
+			  <a :href="curEntry.author" target="_blank" rel="noopener noreferrer" class="col-md-3 mt-3"><span>{{ numberFormat(curEntry.activityCount[0], 0) }} {{$t('Recorded_Activity')}}</span></a>
+			  <div><a :href="$safeUrl(curEntry.url)" target="_blank" rel="noopener noreferrer" class="btn btn-lg btn-brand btn-group-vertical">{{ $t('View_post_details') }}</a></div>
           </div>
         </div>
       </div>

--- a/plugins/sanitize.js
+++ b/plugins/sanitize.js
@@ -1,47 +1,48 @@
 import DOMPurify from 'dompurify';
 
-// Configure the sanitization options
-const sanitizeOptions = {
+// DOMPurify expects ALLOWED_ATTR as a flat array of attribute names.
+// The sanitize-html (SSR) path needs the per-tag object form — kept separate below.
+const domPurifyOptions = {
   ALLOWED_TAGS: [
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol',
     'nl', 'li', 'b', 'i', 'strong', 'em', 'strike', 'code', 'hr', 'br', 'div',
     'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td', 'pre', 'img', 'span'
   ],
-  ALLOWED_ATTR: {
-    a: ['href', 'name', 'target'],
-    img: ['src', 'alt', 'class'],
-    div: ['class'],
-    span: ['class'],
-  },
-  // Allow lots of schemes. A lot of these maybe unsafe, but we need some for custom protocols
-  ALLOWED_URI_REGEXP: /.*/,
-  // For iframes, DOMPurify has ALLOWED_TAGS for iframe, but hostnames are checked in hooks
+  ALLOWED_ATTR: ['href', 'name', 'target', 'src', 'alt', 'class'],
+  // No ALLOWED_URI_REGEXP override — DOMPurify's safe default blocks javascript:, data:, vbscript:
+};
+
+// Per-tag allowedAttributes for sanitize-html (SSR path)
+const sanitizeHtmlAllowedAttributes = {
+  a: ['href', 'name', 'target'],
+  img: ['src', 'alt', 'class'],
+  div: ['class'],
+  span: ['class'],
 };
 
 
 export default ({ app }, inject) => {
   inject('sanitize', (dirty) => {
     if (process.client) {
-      return DOMPurify.sanitize(dirty, sanitizeOptions);
+      return DOMPurify.sanitize(dirty, domPurifyOptions);
     } else {
       const sanitizeHtml = require('sanitize-html');
       return sanitizeHtml(dirty, {
-        allowedTags: sanitizeOptions.ALLOWED_TAGS,
-        allowedAttributes: sanitizeOptions.ALLOWED_ATTR,
+        allowedTags: domPurifyOptions.ALLOWED_TAGS,
+        allowedAttributes: sanitizeHtmlAllowedAttributes,
       });
     }
   });
 
   inject('safeUrl', (url) => {
     if (!url || typeof url !== 'string') return '#';
-    const trimmedUrl = url.trim().toLowerCase();
-    
-    // We still check for dangerous schemes but return the URL anyway 
-    // so it can be handled by the external link prompt in the UI.
-    // However, for critically unsafe usage where no UI prompt exists, 
-    // this might need caution. 
-    // In this project, most links are rendered via components that handle the prompt.
-    
-    return url;
+    const trimmed = url.trim().toLowerCase();
+    if (trimmed.startsWith('/') || trimmed.startsWith('#')) return url;
+    const ALLOWED_SCHEMES = ['http:', 'https:', 'mailto:', 'tel:', 'hive:', 'steem:', 'hivesigner:'];
+    try {
+      const parsed = new URL(url);
+      if (ALLOWED_SCHEMES.includes(parsed.protocol)) return url;
+    } catch {}
+    return '#';
   });
 };

--- a/plugins/vue-custom.js
+++ b/plugins/vue-custom.js
@@ -440,11 +440,14 @@ Vue.prototype.$cleanBody = function (report_content, full_cleanup, no_media){
             if (node.hasAttribute('style')) {
                 let style = node.getAttribute('style');
                 // Remove properties that allow positioning elements outside their container
-                const dangerousProps = ['position', 'z-index', 'top', 'left', 'bottom', 'right', 'inset', 'margin-top', 'margin-left', 'margin-right', 'margin-bottom', 'pointer-events', 'opacity'];
+                // or that can carry javascript:/expression() payloads
+                const dangerousProps = ['position', 'z-index', 'top', 'left', 'bottom', 'right', 'inset', 'margin-top', 'margin-left', 'margin-right', 'margin-bottom', 'pointer-events', 'opacity', 'background-image', 'background'];
                 dangerousProps.forEach(prop => {
                     const regex = new RegExp(prop + '\\s*:\\s*[^;]+;?', 'gi');
                     style = style.replace(regex, '');
                 });
+                // Defence-in-depth: drop any remaining rule whose value contains a dangerous token
+                style = style.replace(/[^:;]+:\s*[^;]*(javascript:|expression\(|url\s*\(javascript)[^;]*;?/gi, '');
                 node.setAttribute('style', style);
             }
             // Restrict iframe src to trusted media hosts — blocks javascript: and arbitrary https embeds

--- a/static/img/1st_place_medal.svg
+++ b/static/img/1st_place_medal.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 70">
+  <defs>
+    <linearGradient id="ribbon" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#e53935"/>
+      <stop offset="50%" style="stop-color:#ff8f00"/>
+      <stop offset="100%" style="stop-color:#e53935"/>
+    </linearGradient>
+    <linearGradient id="medalGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffe066"/>
+      <stop offset="50%" style="stop-color:#d4af37"/>
+      <stop offset="100%" style="stop-color:#a07800"/>
+    </linearGradient>
+  </defs>
+  <!-- Ribbon left -->
+  <rect x="18" y="0" width="10" height="28" rx="3" fill="url(#ribbon)" transform="rotate(-8 23 14)"/>
+  <!-- Ribbon right -->
+  <rect x="32" y="0" width="10" height="28" rx="3" fill="url(#ribbon)" transform="rotate(8 37 14)"/>
+  <!-- Medal circle -->
+  <circle cx="30" cy="46" r="22" fill="url(#medalGrad)" stroke="#a07800" stroke-width="1.5"/>
+  <circle cx="30" cy="46" r="18" fill="none" stroke="#ffe066" stroke-width="1" opacity="0.6"/>
+  <!-- "1" text -->
+  <text x="30" y="53" font-family="Arial,sans-serif" font-size="22" font-weight="bold" fill="#fff" text-anchor="middle" filter="drop-shadow(0 1px 2px rgba(0,0,0,0.4))">1</text>
+</svg>


### PR DESCRIPTION
## Summary

- **Security hardening (AUDIT-046):** closed open redirect (F-09), implemented `$safeUrl()` scheme validation (F-02), fixed DOMPurify config in `sanitize.js` (F-17), routed profile image upload through server-side proxy (F-13), extended CSS strip to cover `background-image`/`url(javascript:)` (F-01 follow-up), enabled nuxt-helmet with HSTS/noSniff/xssFilter/referrerPolicy (F-15), bulk-added `rel="noopener noreferrer"` to all 102 unprotected `target="_blank"` links (F-12), stripped `console.*` from production bundles (F-14)
- **Reward system:** on-chain proof required for all reward endpoints; rate limiting and input validation on proxy; phantom account rejection
- **Signup page:** full UX redesign with step indicator, fee explanation, FAQ accordion, dark mode support, and 14-language i18n coverage
- **Auth hardening:** SC access token validated via `/me` before being written to localStorage; signup credentials moved from GET query string to POST body
- **Content security:** iframe src restricted to trusted media host allowlist (YouTube, 3Speak, Vimeo, Rumble, D.Tube, Facebook); CSS injection patched; mod panel XSS closed
- **DX:** syntax highlighting for code blocks; markdown link rendering fix; version unified — `nuxt.config.js` now reads from `package.json` so only one file needs updating on release
- **Version:** 1.9.x → 1.10.1

## Test plan

- [ ] Load homepage, activity feed, and a post page — no ESLint overlay, no JS errors in console
- [ ] Log in via standard login and via HiveAuth — session persists correctly
- [ ] Vote on a post — reward flow completes without 401/403
- [ ] Upload a profile image — succeeds via `/api/proxy/upload`
- [ ] Open a post with embedded YouTube/Vimeo — iframe renders; attempt an arbitrary iframe src — src is stripped
- [ ] Check response headers on any page — `Strict-Transport-Security`, `X-Content-Type-Options: nosniff`, `X-XSS-Protection` present
- [ ] Verify `window.__nuxt__` or app footer shows version `1.10.1`
- [ ] Confirm no `console.log` output in browser devtools on a production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)