### PR TITLE
chore: bump version to 1.10.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.10.2",
+  "version": "1.10.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actifit-landingpage",
-      "version": "1.10.2",
+      "version": "1.10.4",
       "hasInstallScript": true,
       "dependencies": {
         "@blurtfoundation/blurtjs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "Actifit is an innovative dapp that aims to incentivize fitness and healthy lifestyle via rewarding daily activity.",
   "author": "mktcode",
   "private": true,


### PR DESCRIPTION
## chore: bump version to 1.10.4

Bumps the app version `1.10.3 → 1.10.4` ahead of the release to `master`.

- `package.json`: `1.10.3 → 1.10.4`
- `package-lock.json`: `1.10.2 → 1.10.4` (also unifies the lockfile version, which was lagging behind `package.json`)

Version-only change — no dependency or code changes included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
