### PR TITLE
fix: sync package-lock undici/ws for npm ci

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19085,9 +19085,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -21190,9 +21190,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.4.tgz",
-      "integrity": "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.5.tgz",
+      "integrity": "sha512-G0gACQIjFmv7NqpaOAXEpe9nEtRYD6ZCy2Ip/B4EzR08qEwnf/wYJoQd3cjosPdnJsHkeh0j2tzOaIBZIOC1yA==",
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
@@ -34477,9 +34477,9 @@
       }
     },
     "undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "optional": true,
       "peer": true
     },
@@ -36131,9 +36131,9 @@
       }
     },
     "ws": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.4.tgz",
-      "integrity": "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.5.tgz",
+      "integrity": "sha512-G0gACQIjFmv7NqpaOAXEpe9nEtRYD6ZCy2Ip/B4EzR08qEwnf/wYJoQd3cjosPdnJsHkeh0j2tzOaIBZIOC1yA==",
       "requires": {
         "async-limiter": "~1.0.0"
       }


### PR DESCRIPTION
## fix: sync package-lock for `npm ci`

DigitalOcean App Platform deploys with `npm ci`, which requires `package.json` and `package-lock.json` to be perfectly in sync. The build for commit `68e9dde` failed with:

```
npm ERR! Invalid: lock file's undici@6.25.0 does not satisfy undici@6.26.0
npm ERR! Invalid: lock file's ws@5.2.4 does not satisfy ws@5.2.5
```

The resolved dependency tree requires `undici@6.26.0` and `ws@5.2.5` (both transitive), but the lockfile still pinned the older versions. This restores those entries (in both the `packages` and legacy `dependencies` sections) so `npm ci` passes.

JSON validated; diff is limited to the four `undici`/`ws` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
