### PR TITLE
fix: lockfile sync for DigitalOcean npm ci build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19085,9 +19085,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -21190,9 +21190,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.4.tgz",
-      "integrity": "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.5.tgz",
+      "integrity": "sha512-G0gACQIjFmv7NqpaOAXEpe9nEtRYD6ZCy2Ip/B4EzR08qEwnf/wYJoQd3cjosPdnJsHkeh0j2tzOaIBZIOC1yA==",
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"
@@ -34477,9 +34477,9 @@
       }
     },
     "undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "optional": true,
       "peer": true
     },
@@ -36131,9 +36131,9 @@
       }
     },
     "ws": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.4.tgz",
-      "integrity": "sha512-fFCejsuC8f9kOSu9FYaOw8CdO68O3h5v0lg4p74o8JqWpwTf9tniOD+nOB78aWoVSS6WptVUmDrp/KPsMVBWFQ==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.5.tgz",
+      "integrity": "sha512-G0gACQIjFmv7NqpaOAXEpe9nEtRYD6ZCy2Ip/B4EzR08qEwnf/wYJoQd3cjosPdnJsHkeh0j2tzOaIBZIOC1yA==",
       "requires": {
         "async-limiter": "~1.0.0"
       }


### PR DESCRIPTION
## Release: lockfile sync fix for DigitalOcean build

Promotes `develop` to `master` to fix the failing production deploy.

The previous `master` (`68e9dde`) failed DigitalOcean's `npm ci` because the lockfile was out of sync with `package.json` (`undici@6.25.0`/`ws@5.2.4` pinned while the tree requires `6.26.0`/`5.2.5`). This brings the corrected, in-sync lockfile to `master`.

- **fix: sync package-lock undici/ws for npm ci** (#284)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
