### PR TITLE
docs: correct deployment target to DigitalOcean App Platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Language files live in `lang/` (14 locales, default `en_US.js`). `config/index.j
 
 ## Deployment
 
-No CI pipeline. Deployment is via Heroku: `heroku-postbuild` runs `npm run build`. `.env` is gitignored; required env vars are consumed via `privateRuntimeConfig` and `env` blocks in `nuxt.config.js`.
+No CI pipeline. Production is hosted on **DigitalOcean App Platform** (served behind Cloudflare — live responses carry `x-do-app-origin` headers), which **auto-deploys on push to `master`**. The build runs **`npm ci`** under **Node 16.20.2 / npm 8.19.4**, so `package.json` and `package-lock.json` must stay perfectly in sync or the build fails at install with `EUSAGE`. DigitalOcean uses Heroku-compatible buildpacks, so the `heroku-postbuild` script (`npm run build`) is likely still the build step the buildpack invokes — do not assume it is dead and remove it. `.env` is gitignored; required env vars are configured in the DigitalOcean app and consumed via `privateRuntimeConfig` and `env` blocks in `nuxt.config.js`.
 
 ## Conventions
 


### PR DESCRIPTION
Corrects the stale Heroku note in CLAUDE.md. Documents that production runs on DigitalOcean App Platform, auto-deploys on push to `master` via `npm ci` (Node 16) — so the lockfile must stay in sync — and that `heroku-postbuild` is likely still the buildpack's build step and should not be assumed dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)