### PR TITLE
fix(wallet): silent keychain token refresh+retry for all authenticated actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actifit-landingpage",
-      "version": "1.10.5",
+      "version": "1.10.6",
       "hasInstallScript": true,
       "dependencies": {
         "@blurtfoundation/blurtjs": "^1.0.0",
@@ -4955,6 +4955,32 @@
       },
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/@nuxt/cli/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/@nuxt/cli/node_modules/crc": {
@@ -22257,6 +22283,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -25789,7 +25826,8 @@
         "@babel/plugin-proposal-private-property-in-object": {
           "version": "7.21.0-placeholder-for-preset-env.2",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-          "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w=="
+          "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+          "requires": {}
         },
         "babel-plugin-polyfill-corejs3": {
           "version": "0.10.6",
@@ -25962,7 +26000,8 @@
     "@csstools/cascade-layer-name-parser": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/@csstools/cascade-layer-name-parser/-/cascade-layer-name-parser-1.0.13.tgz",
-      "integrity": "sha512-MX0yLTwtZzr82sQ0zOjqimpZbzjMaK/h2pmlrLK7DCzlmiZLYFpoO94WmN1akRVo6ll/TdpHb53vihHLUMyvng=="
+      "integrity": "sha512-MX0yLTwtZzr82sQ0zOjqimpZbzjMaK/h2pmlrLK7DCzlmiZLYFpoO94WmN1akRVo6ll/TdpHb53vihHLUMyvng==",
+      "requires": {}
     },
     "@csstools/color-helpers": {
       "version": "4.2.1",
@@ -25972,7 +26011,8 @@
     "@csstools/css-calc": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-1.2.4.tgz",
-      "integrity": "sha512-tfOuvUQeo7Hz+FcuOd3LfXVp+342pnWUJ7D2y8NUpu1Ww6xnTbHLpz018/y6rtbHifJ3iIEf9ttxXd8KG7nL0Q=="
+      "integrity": "sha512-tfOuvUQeo7Hz+FcuOd3LfXVp+342pnWUJ7D2y8NUpu1Ww6xnTbHLpz018/y6rtbHifJ3iIEf9ttxXd8KG7nL0Q==",
+      "requires": {}
     },
     "@csstools/css-color-parser": {
       "version": "2.0.5",
@@ -25986,7 +26026,8 @@
     "@csstools/css-parser-algorithms": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.7.1.tgz",
-      "integrity": "sha512-2SJS42gxmACHgikc1WGesXLIT8d/q2l0UFM7TaEeIzdFCE/FPMtTiizcPGGJtlPo2xuQzY09OhrLTzRxqJqwGw=="
+      "integrity": "sha512-2SJS42gxmACHgikc1WGesXLIT8d/q2l0UFM7TaEeIzdFCE/FPMtTiizcPGGJtlPo2xuQzY09OhrLTzRxqJqwGw==",
+      "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "2.4.1",
@@ -25996,7 +26037,8 @@
     "@csstools/media-query-list-parser": {
       "version": "2.1.13",
       "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.13.tgz",
-      "integrity": "sha512-XaHr+16KRU9Gf8XLi3q8kDlI18d5vzKSKCY510Vrtc9iNR0NJzbY9hhTmwhzYZj/ZwGL4VmB3TA9hJW0Um2qFA=="
+      "integrity": "sha512-XaHr+16KRU9Gf8XLi3q8kDlI18d5vzKSKCY510Vrtc9iNR0NJzbY9hhTmwhzYZj/ZwGL4VmB3TA9hJW0Um2qFA==",
+      "requires": {}
     },
     "@csstools/postcss-cascade-layers": {
       "version": "4.0.6",
@@ -26010,7 +26052,8 @@
         "@csstools/selector-specificity": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
-          "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA=="
+          "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+          "requires": {}
         },
         "postcss-selector-parser": {
           "version": "6.1.2",
@@ -26124,7 +26167,8 @@
     "@csstools/postcss-initial": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-initial/-/postcss-initial-1.0.1.tgz",
-      "integrity": "sha512-wtb+IbUIrIf8CrN6MLQuFR7nlU5C7PwuebfeEXfjthUha1+XZj2RVi+5k/lukToA24sZkYAiSJfHM8uG/UZIdg=="
+      "integrity": "sha512-wtb+IbUIrIf8CrN6MLQuFR7nlU5C7PwuebfeEXfjthUha1+XZj2RVi+5k/lukToA24sZkYAiSJfHM8uG/UZIdg==",
+      "requires": {}
     },
     "@csstools/postcss-is-pseudo-class": {
       "version": "4.0.8",
@@ -26138,7 +26182,8 @@
         "@csstools/selector-specificity": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
-          "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA=="
+          "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+          "requires": {}
         },
         "postcss-selector-parser": {
           "version": "6.1.2",
@@ -26165,17 +26210,20 @@
     "@csstools/postcss-logical-float-and-clear": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-float-and-clear/-/postcss-logical-float-and-clear-2.0.1.tgz",
-      "integrity": "sha512-SsrWUNaXKr+e/Uo4R/uIsqJYt3DaggIh/jyZdhy/q8fECoJSKsSMr7nObSLdvoULB69Zb6Bs+sefEIoMG/YfOA=="
+      "integrity": "sha512-SsrWUNaXKr+e/Uo4R/uIsqJYt3DaggIh/jyZdhy/q8fECoJSKsSMr7nObSLdvoULB69Zb6Bs+sefEIoMG/YfOA==",
+      "requires": {}
     },
     "@csstools/postcss-logical-overflow": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-overflow/-/postcss-logical-overflow-1.0.1.tgz",
-      "integrity": "sha512-Kl4lAbMg0iyztEzDhZuQw8Sj9r2uqFDcU1IPl+AAt2nue8K/f1i7ElvKtXkjhIAmKiy5h2EY8Gt/Cqg0pYFDCw=="
+      "integrity": "sha512-Kl4lAbMg0iyztEzDhZuQw8Sj9r2uqFDcU1IPl+AAt2nue8K/f1i7ElvKtXkjhIAmKiy5h2EY8Gt/Cqg0pYFDCw==",
+      "requires": {}
     },
     "@csstools/postcss-logical-overscroll-behavior": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-logical-overscroll-behavior/-/postcss-logical-overscroll-behavior-1.0.1.tgz",
-      "integrity": "sha512-+kHamNxAnX8ojPCtV8WPcUP3XcqMFBSDuBuvT6MHgq7oX4IQxLIXKx64t7g9LiuJzE7vd06Q9qUYR6bh4YnGpQ=="
+      "integrity": "sha512-+kHamNxAnX8ojPCtV8WPcUP3XcqMFBSDuBuvT6MHgq7oX4IQxLIXKx64t7g9LiuJzE7vd06Q9qUYR6bh4YnGpQ==",
+      "requires": {}
     },
     "@csstools/postcss-logical-resize": {
       "version": "2.0.1",
@@ -26315,12 +26363,14 @@
     "@csstools/postcss-unset-value": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/postcss-unset-value/-/postcss-unset-value-3.0.1.tgz",
-      "integrity": "sha512-dbDnZ2ja2U8mbPP0Hvmt2RMEGBiF1H7oY6HYSpjteXJGihYwgxgTr6KRbbJ/V6c+4wd51M+9980qG4gKVn5ttg=="
+      "integrity": "sha512-dbDnZ2ja2U8mbPP0Hvmt2RMEGBiF1H7oY6HYSpjteXJGihYwgxgTr6KRbbJ/V6c+4wd51M+9980qG4gKVn5ttg==",
+      "requires": {}
     },
     "@csstools/utilities": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@csstools/utilities/-/utilities-1.0.0.tgz",
-      "integrity": "sha512-tAgvZQe/t2mlvpNosA4+CkMiZ2azISW5WPAcdSalZlEjQvUfghHxfQcrCiK/7/CrfAWVxyM88kGFYO82heIGDg=="
+      "integrity": "sha512-tAgvZQe/t2mlvpNosA4+CkMiZ2azISW5WPAcdSalZlEjQvUfghHxfQcrCiK/7/CrfAWVxyM88kGFYO82heIGDg==",
+      "requires": {}
     },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -27194,17 +27244,20 @@
     "@jsonjoy.com/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA=="
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "requires": {}
     },
     "@jsonjoy.com/buffers": {
       "version": "17.67.0",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
-      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw=="
+      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+      "requires": {}
     },
     "@jsonjoy.com/codegen": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
-      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g=="
+      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+      "requires": {}
     },
     "@jsonjoy.com/fs-core": {
       "version": "4.57.2",
@@ -27244,7 +27297,8 @@
     "@jsonjoy.com/fs-node-builtins": {
       "version": "4.57.2",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.57.2.tgz",
-      "integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg=="
+      "integrity": "sha512-xhiegylRmhw43Ki2HO1ZBL7DQ5ja/qpRsL29VtQ2xuUHiuDGbgf2uD4p9Qd8hJI5P6RCtGYD50IXHXVq/Ocjcg==",
+      "requires": {}
     },
     "@jsonjoy.com/fs-node-to-fsa": {
       "version": "4.57.2",
@@ -27287,12 +27341,14 @@
         "@jsonjoy.com/base64": {
           "version": "17.67.0",
           "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
-          "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw=="
+          "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+          "requires": {}
         },
         "@jsonjoy.com/codegen": {
           "version": "17.67.0",
           "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
-          "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q=="
+          "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+          "requires": {}
         },
         "@jsonjoy.com/json-pack": {
           "version": "17.67.0",
@@ -27346,7 +27402,8 @@
         "@jsonjoy.com/buffers": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
-          "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA=="
+          "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+          "requires": {}
         }
       }
     },
@@ -27371,7 +27428,8 @@
         "@jsonjoy.com/buffers": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
-          "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA=="
+          "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+          "requires": {}
         }
       }
     },
@@ -27537,10 +27595,22 @@
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
         "crc": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/crc/-/crc-4.3.2.tgz",
-          "integrity": "sha512-uGDHf4KLLh2zsHa8D8hIQ1H/HtFQhyHrc0uhHBcoKGol/Xnb+MPYfUMw7cvON6ze/GUESTudKayDcJC5HnJv1A=="
+          "integrity": "sha512-uGDHf4KLLh2zsHa8D8hIQ1H/HtFQhyHrc0uhHBcoKGol/Xnb+MPYfUMw7cvON6ze/GUESTudKayDcJC5HnJv1A==",
+          "requires": {}
         }
       }
     },
@@ -28957,7 +29027,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.3.5",
@@ -29002,7 +29073,8 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "requires": {}
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -29033,7 +29105,8 @@
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -29574,7 +29647,8 @@
     "bootstrap": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ=="
+      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "requires": {}
     },
     "bootstrap-vue": {
       "version": "2.23.1",
@@ -30683,7 +30757,8 @@
     "css-declaration-sorter": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
-      "integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw=="
+      "integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
+      "requires": {}
     },
     "css-has-pseudo": {
       "version": "6.0.5",
@@ -30698,7 +30773,8 @@
         "@csstools/selector-specificity": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
-          "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA=="
+          "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+          "requires": {}
         },
         "postcss-selector-parser": {
           "version": "6.1.2",
@@ -30731,7 +30807,8 @@
     "css-prefers-color-scheme": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-9.0.1.tgz",
-      "integrity": "sha512-iFit06ochwCKPRiWagbTa1OAWCvWWVdEnIFd8BaRrgO8YrrNh4RAWUQTFcYX5tdFZgFl1DJ3iiULchZyEbnF4g=="
+      "integrity": "sha512-iFit06ochwCKPRiWagbTa1OAWCvWWVdEnIFd8BaRrgO8YrrNh4RAWUQTFcYX5tdFZgFl1DJ3iiULchZyEbnF4g==",
+      "requires": {}
     },
     "css-select": {
       "version": "5.2.2",
@@ -30823,7 +30900,8 @@
     "cssnano-utils": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.2.tgz",
-      "integrity": "sha512-kt41WLK7FLKfePzPi645Y+/NtW/nNM7Su6nlNUfJyRNW3JcuU3JU7+cWJc+JexTeZ8dRBvFufefdG2XpXkIo0A=="
+      "integrity": "sha512-kt41WLK7FLKfePzPi645Y+/NtW/nNM7Su6nlNUfJyRNW3JcuU3JU7+cWJc+JexTeZ8dRBvFufefdG2XpXkIo0A==",
+      "requires": {}
     },
     "csso": {
       "version": "5.0.5",
@@ -32740,7 +32818,8 @@
     "glob-to-regex.js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
-      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ=="
+      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+      "requires": {}
     },
     "glob-to-regexp": {
       "version": "0.4.1",
@@ -33511,7 +33590,8 @@
     "icss-utils": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "requires": {}
     },
     "idna-uts46-hx": {
       "version": "2.3.1",
@@ -34419,7 +34499,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -35347,7 +35428,8 @@
     "marked-highlight": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.4.tgz",
-      "integrity": "sha512-PZxisNMJDduSjc0q6uvjsnqqHCXc9s0eyzxDO9sB1eNGJnd/H1/Fu+z6g/liC1dfJdFW4SftMwMlLvsBhUPrqQ=="
+      "integrity": "sha512-PZxisNMJDduSjc0q6uvjsnqqHCXc9s0eyzxDO9sB1eNGJnd/H1/Fu+z6g/liC1dfJdFW4SftMwMlLvsBhUPrqQ==",
+      "requires": {}
     },
     "match-at": {
       "version": "0.1.1",
@@ -36163,7 +36245,8 @@
         "css-declaration-sorter": {
           "version": "6.4.1",
           "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
-          "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g=="
+          "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
+          "requires": {}
         },
         "cssnano": {
           "version": "5.1.15",
@@ -36214,7 +36297,8 @@
         "cssnano-utils": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
-          "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA=="
+          "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
+          "requires": {}
         },
         "lilconfig": {
           "version": "2.1.0",
@@ -36258,22 +36342,26 @@
         "postcss-discard-comments": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.2.tgz",
-          "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ=="
+          "integrity": "sha512-+L8208OVbHVF2UQf1iDmRcbdjJkuBF6IS29yBDSiWUIzpYaAhtNl6JYnYm12FnkeCwQqF5LeklOu6rAqgfBZqQ==",
+          "requires": {}
         },
         "postcss-discard-duplicates": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
-          "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw=="
+          "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
+          "requires": {}
         },
         "postcss-discard-empty": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
-          "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A=="
+          "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
+          "requires": {}
         },
         "postcss-discard-overridden": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
-          "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw=="
+          "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
+          "requires": {}
         },
         "postcss-merge-longhand": {
           "version": "5.1.7",
@@ -36334,7 +36422,8 @@
         "postcss-normalize-charset": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
-          "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg=="
+          "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
+          "requires": {}
         },
         "postcss-normalize-display-values": {
           "version": "5.1.0",
@@ -36954,7 +37043,8 @@
     "portal-vue": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/portal-vue/-/portal-vue-2.1.7.tgz",
-      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g=="
+      "integrity": "sha512-+yCno2oB3xA7irTt0EU5Ezw22L2J51uKAacE/6hMPMoO/mx3h4rXFkkBkT4GFsMDv/vEe8TNKC3ujJJ0PTwb6g==",
+      "requires": {}
     },
     "possible-typed-array-names": {
       "version": "1.1.0",
@@ -37132,17 +37222,20 @@
     "postcss-discard-duplicates": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.3.tgz",
-      "integrity": "sha512-9cRxXwhEM/aNZon1qZyToX4NmjbFbxOGbww+0CnbYFDbbPRGZ8jg4IbM8UlA+CzkXxM35itxyaHKNqBBg/RTDg=="
+      "integrity": "sha512-9cRxXwhEM/aNZon1qZyToX4NmjbFbxOGbww+0CnbYFDbbPRGZ8jg4IbM8UlA+CzkXxM35itxyaHKNqBBg/RTDg==",
+      "requires": {}
     },
     "postcss-discard-empty": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.2.tgz",
-      "integrity": "sha512-NZFouOmOwtngJVgkNeI1LtkzFdYqIurxgy4wq3qNvIiXFURTZ3b/K7q3dP3QitlWQ5imHDQL0qSorItQhoxb1g=="
+      "integrity": "sha512-NZFouOmOwtngJVgkNeI1LtkzFdYqIurxgy4wq3qNvIiXFURTZ3b/K7q3dP3QitlWQ5imHDQL0qSorItQhoxb1g==",
+      "requires": {}
     },
     "postcss-discard-overridden": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.2.tgz",
-      "integrity": "sha512-Ym01X4v6U3sY8X0P1J9P+RTar+7JyLTOzDrxKSeaArFsLmkVu4KcAKPBWDYRIyZ/q4jwpSPnOnekeSSqXSXKUw=="
+      "integrity": "sha512-Ym01X4v6U3sY8X0P1J9P+RTar+7JyLTOzDrxKSeaArFsLmkVu4KcAKPBWDYRIyZ/q4jwpSPnOnekeSSqXSXKUw==",
+      "requires": {}
     },
     "postcss-double-position-gradients": {
       "version": "5.0.7",
@@ -37195,12 +37288,14 @@
     "postcss-font-variant": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
-      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA=="
+      "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
+      "requires": {}
     },
     "postcss-gap-properties": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-5.0.1.tgz",
-      "integrity": "sha512-k2z9Cnngc24c0KF4MtMuDdToROYqGMMUQGcE6V0odwjHyOHtaDBlLeRBV70y9/vF7KIbShrTRZ70JjsI1BZyWw=="
+      "integrity": "sha512-k2z9Cnngc24c0KF4MtMuDdToROYqGMMUQGcE6V0odwjHyOHtaDBlLeRBV70y9/vF7KIbShrTRZ70JjsI1BZyWw==",
+      "requires": {}
     },
     "postcss-image-set-function": {
       "version": "6.0.3",
@@ -37323,7 +37418,8 @@
     "postcss-modules-extract-imports": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
-      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q=="
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.2.0",
@@ -37364,12 +37460,14 @@
         "@csstools/selector-resolve-nested": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-1.1.0.tgz",
-          "integrity": "sha512-uWvSaeRcHyeNenKg8tp17EVDRkpflmdyvbE0DHo6D/GdBb6PDnCYYU6gRpXhtICMGMcahQmj2zGxwFM/WC8hCg=="
+          "integrity": "sha512-uWvSaeRcHyeNenKg8tp17EVDRkpflmdyvbE0DHo6D/GdBb6PDnCYYU6gRpXhtICMGMcahQmj2zGxwFM/WC8hCg==",
+          "requires": {}
         },
         "@csstools/selector-specificity": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.1.1.tgz",
-          "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA=="
+          "integrity": "sha512-a7cxGcJ2wIlMFLlh8z2ONm+715QkPHiyJcxwQlKOz/03GPw1COpfhcmC9wm4xlZfp//jWHNNMwzjtqHXVWU9KA==",
+          "requires": {}
         },
         "postcss-selector-parser": {
           "version": "6.1.2",
@@ -37385,7 +37483,8 @@
     "postcss-normalize-charset": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.2.tgz",
-      "integrity": "sha512-YoINoiR4YKlzfB95Y93b0DSxWy7FLw+1SADIaznMHb88AKizpzfF80tolmiDEbYr1UM4r4Hw+NZq37SwT5f3uw=="
+      "integrity": "sha512-YoINoiR4YKlzfB95Y93b0DSxWy7FLw+1SADIaznMHb88AKizpzfF80tolmiDEbYr1UM4r4Hw+NZq37SwT5f3uw==",
+      "requires": {}
     },
     "postcss-normalize-display-values": {
       "version": "7.0.2",
@@ -37455,7 +37554,8 @@
     "postcss-opacity-percentage": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-2.0.0.tgz",
-      "integrity": "sha512-lyDrCOtntq5Y1JZpBFzIWm2wG9kbEdujpNt4NLannF+J9c8CgFIzPa80YQfdza+Y+yFfzbYj/rfoOsYsooUWTQ=="
+      "integrity": "sha512-lyDrCOtntq5Y1JZpBFzIWm2wG9kbEdujpNt4NLannF+J9c8CgFIzPa80YQfdza+Y+yFfzbYj/rfoOsYsooUWTQ==",
+      "requires": {}
     },
     "postcss-ordered-values": {
       "version": "7.0.3",
@@ -37477,7 +37577,8 @@
     "postcss-page-break": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
-      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ=="
+      "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
+      "requires": {}
     },
     "postcss-place": {
       "version": "9.0.1",
@@ -37594,7 +37695,8 @@
     "postcss-replace-overflow-wrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
-      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw=="
+      "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
+      "requires": {}
     },
     "postcss-selector-not": {
       "version": "7.0.2",
@@ -39698,7 +39800,8 @@
     "thingies": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.6.0.tgz",
-      "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg=="
+      "integrity": "sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==",
+      "requires": {}
     },
     "thread-loader": {
       "version": "3.0.4",
@@ -39735,7 +39838,8 @@
     "time-fix-plugin": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/time-fix-plugin/-/time-fix-plugin-2.0.7.tgz",
-      "integrity": "sha512-uVFet1LQToeUX0rTcSiYVYVoGuBpc8gP/2jnlUzuHMHe+gux6XLsNzxLUweabMwiUj5ejhoIMsUI55nVSEa/Vw=="
+      "integrity": "sha512-uVFet1LQToeUX0rTcSiYVYVoGuBpc8gP/2jnlUzuHMHe+gux6XLsNzxLUweabMwiUj5ejhoIMsUI55nVSEa/Vw==",
+      "requires": {}
     },
     "timed-out": {
       "version": "4.0.1",
@@ -39835,7 +39939,8 @@
     "tree-dump": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
-      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA=="
+      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+      "requires": {}
     },
     "ts-pnp": {
       "version": "1.2.0",
@@ -40005,6 +40110,13 @@
         "has-symbols": "^1.1.0",
         "which-boxed-primitive": "^1.1.1"
       }
+    },
+    "undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "optional": true,
+      "peer": true
     },
     "undici-types": {
       "version": "7.19.2",
@@ -40466,12 +40578,14 @@
     "vue-notification": {
       "version": "1.3.20",
       "resolved": "https://registry.npmjs.org/vue-notification/-/vue-notification-1.3.20.tgz",
-      "integrity": "sha512-vPj67Ah72p8xvtyVE8emfadqVWguOScAjt6OJDEUdcW5hW189NsqvfkOrctxHUUO9UYl9cTbIkzAEcPnHu+zBQ=="
+      "integrity": "sha512-vPj67Ah72p8xvtyVE8emfadqVWguOScAjt6OJDEUdcW5hW189NsqvfkOrctxHUUO9UYl9cTbIkzAEcPnHu+zBQ==",
+      "requires": {}
     },
     "vue-recaptcha": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/vue-recaptcha/-/vue-recaptcha-1.3.0.tgz",
-      "integrity": "sha512-9Qf1niyHq4QbEUhsvdUkS8BoOyhYwpp8v+imUSj67ffDo9RQ6h8Ekq8EGnw/GKViXCwWalp7EEY/n/fOtU0FyA=="
+      "integrity": "sha512-9Qf1niyHq4QbEUhsvdUkS8BoOyhYwpp8v+imUSj67ffDo9RQ6h8Ekq8EGnw/GKViXCwWalp7EEY/n/fOtU0FyA==",
+      "requires": {}
     },
     "vue-recaptcha-v3": {
       "version": "1.9.0",
@@ -40624,7 +40738,8 @@
     "vuex": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw=="
+      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==",
+      "requires": {}
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -41394,7 +41509,8 @@
         },
         "ws": {
           "version": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-          "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="
+          "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+          "requires": {}
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.10.5",
+  "version": "1.10.6",
   "description": "Actifit is an innovative dapp that aims to incentivize fitness and healthy lifestyle via rewarding daily activity.",
   "author": "mktcode",
   "private": true,

--- a/pages/_username/wallet.vue
+++ b/pages/_username/wallet.vue
@@ -5428,15 +5428,9 @@ export default {
         return;
       }
       let passVal = this.$refs['funds-pass'].value;
-      let outcome = await this.postSetFundsPass(passVal);
-      //if the session token was rejected (e.g. an expired keychain session), silently
-      //refresh it via the keychain handshake and retry once before surfacing an error
-      if (this.isAuthFailure(outcome)) {
-        let refreshed = await this.ensureKeychainToken();
-        if (refreshed) {
-          outcome = await this.postSetFundsPass(passVal);
-        }
-      }
+      let setUrl = process.env.actiAppUrl + 'setUserFundsPass?user=' + this.user.account.name;
+      //silently refresh an expired keychain token and retry once if the token is rejected
+      let outcome = await this.withAuthRetry(() => this.postAuthed(setUrl, JSON.stringify({ pass: passVal })));
       this.settingPass = false;
       //only advance when the API actually persisted the record (status === 'Success').
       //any other shape (e.g. {error}, or an auth rejection {success:false, message})
@@ -5457,21 +5451,44 @@ export default {
         console.error('setUserFundsPass failed:', outcome);
       }
     },
-    //posts the funds password with the current session token; returns the parsed API response
-    async postSetFundsPass(passVal) {
-      const accToken = localStorage.getItem('access_token');
-      const url = new URL(process.env.actiAppUrl + 'setUserFundsPass?user=' + this.user.account.name);
+    //POST a JSON body to an authenticated (checkHdrs) endpoint using the current session token
+    async postAuthed(url, body) {
       try {
         let res = await fetch(url, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'x-acti-token': 'Bearer ' + accToken },
-          body: JSON.stringify({ pass: passVal }),
+          headers: { 'Content-Type': 'application/json', 'x-acti-token': 'Bearer ' + localStorage.getItem('access_token') },
+          body: body,
         });
         return await res.json();
       } catch (e) {
-        console.error('setUserFundsPass request error:', e);
+        console.error('authed POST failed:', url, e);
         return { error: this.$t('error_performing_operation') };
       }
+    },
+    //GET an authenticated (checkHdrs) endpoint using the current session token
+    async getAuthed(url) {
+      try {
+        let res = await fetch(url, {
+          headers: { 'Content-Type': 'application/json', 'x-acti-token': 'Bearer ' + localStorage.getItem('access_token') },
+        });
+        return await res.json();
+      } catch (e) {
+        console.error('authed GET failed:', url, e);
+        return { error: this.$t('error_performing_operation') };
+      }
+    },
+    //runs an authenticated request (fn must return the parsed API response); if the token
+    //was rejected, silently refresh it via keychain once and retry, so keychain users
+    //aren't bounced to a re-login mid-action
+    async withAuthRetry(fn) {
+      let outcome = await fn();
+      if (this.isAuthFailure(outcome)) {
+        let refreshed = await this.ensureKeychainToken();
+        if (refreshed) {
+          outcome = await fn();
+        }
+      }
+      return outcome;
     },
     //true when the API response indicates the session token was missing/expired/invalid
     isAuthFailure(outcome) {
@@ -5732,14 +5749,9 @@ export default {
         return;
       }
       this.tipInProgress = true;
-      //proceed with tipping
-      const accToken = localStorage.getItem('access_token');
-      let res = await fetch(process.env.actiAppUrl + 'tipAccount/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-acti-token': 'Bearer ' + accToken },
-        body: JSON.stringify({ targetUser: this.$refs['tip-recipient'].value, amount: this.$refs["tip-amount"].value, fundsPass: this.$refs["funds-pass"].value })
-      });
-      let outcome = await res.json();
+      //proceed with tipping (silently refresh + retry if the keychain token expired)
+      let tipBody = JSON.stringify({ targetUser: this.$refs['tip-recipient'].value, amount: this.$refs["tip-amount"].value, fundsPass: this.$refs["funds-pass"].value });
+      let outcome = await this.withAuthRetry(() => this.postAuthed(process.env.actiAppUrl + 'tipAccount/', tipBody));
       if (outcome.status == 'Success') {
         let tipTransaction = { action: 'Tip', amount: outcome.tipAmount, recipient: this.displayUser };
         //store the transaction to Steem BC
@@ -5772,6 +5784,8 @@ export default {
         }
 
         this.proceedTip = false;
+      } else if (this.isAuthFailure(outcome)) {
+        this.tipError = this.$t('session_expired_login_again');
       } else {
         this.tipError = outcome.error;
       }
@@ -5858,14 +5872,9 @@ export default {
       //otherwise we're good, let's register the move
 
 
-      //proceed with tipping
-      const moveAccToken = localStorage.getItem('access_token');
-      let res = await fetch(process.env.actiAppUrl + 'initiateAFITMoveSE/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-acti-token': 'Bearer ' + moveAccToken },
-        body: JSON.stringify({ amount: amount_to_powerdown, fundsPass: this.$refs["move-funds-pass"].value })
-      });
-      let outcome = await res.json();
+      //register the move (silently refresh + retry if the keychain token expired)
+      let moveBody = JSON.stringify({ amount: amount_to_powerdown, fundsPass: this.$refs["move-funds-pass"].value });
+      let outcome = await this.withAuthRetry(() => this.postAuthed(process.env.actiAppUrl + 'initiateAFITMoveSE/', moveBody));
       if (outcome.status == 'Success') {
         let afitPDTransaction = { action: 'AFIT To S-E Power Down', amount: amount_to_powerdown };
         //store the transaction to Steem BC
@@ -5894,7 +5903,7 @@ export default {
 
       } else {
         this.afit_se_move_error_proceeding = true;
-        this.afit_se_move_err_msg = outcome.error;
+        this.afit_se_move_err_msg = this.isAuthFailure(outcome) ? this.$t('session_expired_login_again') : outcome.error;
       }
       this.initiateInProgress = false;
 
@@ -7928,18 +7937,9 @@ export default {
       if (!confirmPopup) {
         return;
       }
-      let accToken = localStorage.getItem('access_token')
-
       let url = new URL(process.env.actiAppUrl + 'resetFundsPass/?user=' + this.user.account.name);
-
-      let reqHeads = new Headers({
-        'Content-Type': 'application/json',
-        'x-acti-token': 'Bearer ' + accToken,
-      });
-      let res = await fetch(url, {
-        headers: reqHeads
-      });
-      let outcome = await res.json();
+      //silently refresh + retry if the keychain token expired
+      let outcome = await this.withAuthRetry(() => this.getAuthed(url));
       console.log(outcome);
       if (outcome.status == 'success') {
         //explicit reset -> drop the pending marker and return to step 1
@@ -7956,7 +7956,7 @@ export default {
       } else {
         this.$notify({
           group: 'error',
-          text: this.$t('problem_reset_pass'),
+          text: this.isAuthFailure(outcome) ? this.$t('session_expired_login_again') : this.$t('problem_reset_pass'),
           position: 'top center'
         })
       }


### PR DESCRIPTION
## Summary
Follow-up to PR #288. Extends the keychain session hardening (already applied to **setUserFundsPass**) to the remaining `checkHdrs`-protected wallet actions, so an expired/invalid keychain token **self-recovers** instead of failing the action.

### Covered actions
- `tipAccount` (Send AFIT / tip)
- `initiateAFITMoveSE` (AFIT → Hive-Engine move)
- `resetFundsPass`

### How
- New shared helpers: `postAuthed(url, body)`, `getAuthed(url)`, and `withAuthRetry(fn)`.
- On a token-rejection response, `withAuthRetry` silently re-mints the keychain token via the challenge handshake (`ensureKeychainToken`) and retries the request once.
- If the refresh can't recover, the action surfaces the friendly `session_expired_login_again` message instead of a blank/cryptic error.
- `setUserFundsPass` refactored onto the same shared helpers (no behavior change).

### Not included
- `cancelAFITMoveSE` — intentionally excluded; it is **not** `checkHdrs`-gated (verifies via fundsPass in the body, no session token).

Version bumped to 1.10.6. Compiles clean (client + server). No backend change required — relies on the `loginKeychainVerify` endpoint already deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)