### PR TITLE
Release 1.10.7: stored-XSS fix in $cleanBody

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actifit-landingpage",
-      "version": "1.10.6",
+      "version": "1.10.7",
       "hasInstallScript": true,
       "dependencies": {
         "@blurtfoundation/blurtjs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.10.6",
+  "version": "1.10.7",
   "description": "Actifit is an innovative dapp that aims to incentivize fitness and healthy lifestyle via rewarding daily activity.",
   "author": "mktcode",
   "private": true,

--- a/plugins/vue-custom.js
+++ b/plugins/vue-custom.js
@@ -372,6 +372,16 @@ Vue.prototype.$cleanBody = function (report_content, full_cleanup, no_media){
 		return stashResult(`<div class="video-container"><iframe width="640" height="360" src="https://www.youtube.com/embed/${v}" frameborder="0" allowfullscreen></iframe></div>`);
 	});
 
+	// Escape characters that are significant inside an HTML attribute value so a
+	// crafted URL cannot terminate the src="" attribute and inject new attributes
+	// (e.g. onerror=). Defence against stored XSS via image/media URLs.
+	const escapeHtmlAttr = (str) => String(str)
+		.replace(/&/g, '&amp;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+
 	// Process Images (unified approach)
 	const createProxiedImageTag = (url) => {
 		if (!url || typeof url !== 'string') return '';
@@ -380,13 +390,16 @@ Vue.prototype.$cleanBody = function (report_content, full_cleanup, no_media){
 		const proxiedUrl = (url.startsWith('https://images.hive.blog') || url.toLowerCase().endsWith('.gif'))
 			? url
 			: `https://images.hive.blog/0x0/${url}`;
-		return `<img src="${proxiedUrl}">`;
+		return `<img src="${escapeHtmlAttr(proxiedUrl)}">`;
 	};
 
 	const existingImgRegex = /<img\s+[^>]*?src\s*=\s*['"]([^'"]+)['"][^>]*?>/gi;
 	report_content = report_content.replace(existingImgRegex, (match, url) => stashResult(createProxiedImageTag(url)));
 
-	const markdownImgRegex = /!\[[^\]]*\]\s*\(([^)]+)\)/g;
+	// URL capture rejects quotes, whitespace and angle brackets so it cannot carry
+	// an attribute-breakout payload, and requires ']( ' adjacency (matching the
+	// markdownLinkRegex protective pass) so no crafted-whitespace variant slips through.
+	const markdownImgRegex = /!\[[^\]]*\]\(([^\s"'<>)]+)\)/g;
 	report_content = report_content.replace(markdownImgRegex, (match, url) => stashResult(createProxiedImageTag(url)));
 
 	const rawImgRegex = /(^|\s)(https?:\/\/[^\s"'<>]*\.(?:png|jpg|jpeg|gif|webp))/g;
@@ -412,8 +425,17 @@ Vue.prototype.$cleanBody = function (report_content, full_cleanup, no_media){
 	let html_content = marked.parse(report_content, { breaks: true, gfm: true });
 
 	// =========================================================================
-	// ===== STEP 3: RESTORE PLACEHOLDERS AND SANITIZE ========================
+	// ===== STEP 3: RESTORE PLACEHOLDERS, THEN SANITIZE ======================
 	// =========================================================================
+
+	// Restore stashed media/mention HTML BEFORE sanitizing so it passes through
+	// DOMPurify / sanitize-html too. Restoring after sanitization (the previous
+	// behaviour) re-injected raw, attacker-influenced markup that the sanitizer
+	// never saw — a stored-XSS hole. This also makes the iframe host allow-list
+	// and link whitelist actually apply to stashed content.
+	for (const placeholder in placeholders) {
+		html_content = html_content.replace(placeholder, placeholders[placeholder]);
+	}
 
 	let sanitizeOptions = {
 		ALLOWED_TAGS: [ 'img', 'iframe', 'details', 'summary', 'table', 'tr', 'td', 'th', 'thead', 'tbody', 'sub', 'sup', 'div', 'a', 'p', 'br', 'strong', 'em', 'u', 's', 'blockquote', 'code', 'pre', 'ul', 'ol', 'li', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'span' ],
@@ -492,11 +514,6 @@ Vue.prototype.$cleanBody = function (report_content, full_cleanup, no_media){
                 }
             }
         });
-    }
-
-    // RESTORE PLACEHOLDERS AFTER SANITIZATION
-    for (const placeholder in placeholders) {
-        sanitized_html = sanitized_html.replace(placeholder, placeholders[placeholder]);
     }
 
 	// =========================================================================

--- a/test/unit/plugins/vue-custom.spec.js
+++ b/test/unit/plugins/vue-custom.spec.js
@@ -55,6 +55,80 @@ describe('plugins/vue-custom global helpers', () => {
     })
   })
 
+  describe('$cleanBody (client sanitize path)', () => {
+    // The reported stored-XSS fired in the browser (DOMPurify) path, so exercise it.
+    beforeAll(() => { process.client = true })
+    afterAll(() => { delete process.client })
+
+    const clean = (body) => Vue.prototype.$cleanBody(body, false, false)
+
+    // Parse the returned HTML the way the browser will and assert the real
+    // security property: no element carries an on* event-handler attribute
+    // (a "onerror" substring surviving as inert text content is harmless).
+    const eventHandlerAttrs = (html) => {
+      const root = document.createElement('div')
+      root.innerHTML = html
+      return Array.from(root.querySelectorAll('*'))
+        .flatMap(el => Array.from(el.attributes).map(a => a.name))
+        .filter(name => /^on/i.test(name))
+    }
+
+    // --- Security: the reported payloads must be neutralised ---
+    it('neutralises the markdown-image src breakout XSS (adjacent form)', () => {
+      const html = clean('![x](https://z.gif" onerror="alert(document.domain))')
+      expect(eventHandlerAttrs(html)).toEqual([])
+      expect(html).not.toContain('<script')
+    })
+
+    it('neutralises the whitespace-variant that dodged the link pass', () => {
+      const html = clean('![x] (https://z.gif" onerror="alert(document.domain))')
+      expect(eventHandlerAttrs(html)).toEqual([])
+      expect(html).not.toContain('<script')
+    })
+
+    it('escapes a quote in an image URL instead of breaking out of src', () => {
+      const html = clean('foo https://evil.com/a.png" onerror="alert(1) bar')
+      expect(eventHandlerAttrs(html)).toEqual([])
+      // the img that IS produced must carry only a clean, single-URL src
+      const root = document.createElement('div')
+      root.innerHTML = html
+      root.querySelectorAll('img').forEach(img => {
+        expect(img.getAttribute('src')).not.toMatch(/["\s]/)
+      })
+    })
+
+    // --- Functionality: media/mentions must still render ---
+    it('still proxies a bare image URL through images.hive.blog', () => {
+      const html = clean('https://example.com/pic.png')
+      expect(html).toContain('<img')
+      expect(html).toContain('images.hive.blog/0x0/https://example.com/pic.png')
+    })
+
+    it('passes .gif URLs through without proxying', () => {
+      const html = clean('https://example.com/a.gif')
+      expect(html).toContain('<img')
+      expect(html).toContain('https://example.com/a.gif')
+      expect(html).not.toContain('images.hive.blog/0x0/')
+    })
+
+    it('still renders a YouTube embed as a trusted iframe', () => {
+      const html = clean('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+      expect(html).toContain('<iframe')
+      expect(html).toContain('youtube.com/embed/dQw4w9WgXcQ')
+    })
+
+    it('still renders a 3Speak embed as a trusted iframe', () => {
+      const html = clean('https://3speak.tv/watch?v=user/abcdefg')
+      expect(html).toContain('<iframe')
+      expect(html).toContain('3speak.tv/watch?v=user/abcdefg')
+    })
+
+    it('still renders @mentions as actifit links', () => {
+      const html = clean('hello @cr0w how are you')
+      expect(html).toContain('href="https://actifit.io/@cr0w"')
+    })
+  })
+
   describe('$fetchReportTags', () => {
     beforeAll(() => { process.client = false }) // exercise the SSR regex-strip path
     afterAll(() => { delete process.client })


### PR DESCRIPTION
Promotes the stored-XSS fix (#294) and version bump 1.10.7 from develop to master for production deploy.

- fix(security): close stored XSS in `$cleanBody` media restore path (#294)
- chore: bump version to 1.10.7

Auto-deploys to actifit.io on merge to master.