### PR TITLE
fix(3speak): embed play.3speak.tv/embed?v= URL form as a player

### DIFF
--- a/plugins/vue-custom.js
+++ b/plugins/vue-custom.js
@@ -356,12 +356,14 @@ Vue.prototype.$cleanBody = function (report_content, full_cleanup, no_media){
 	});
 
 	// Process 3Speak
-	let threespk_embed_reg = /\[!\[[^\]]*\]\([^)]+\)\]\(https?:\/\/3speak\.tv\/watch\?v=([\w.-]+\/[\w.-]+)\)/ig;
+	// Accept both URL shapes — 3speak.tv/watch?v= and play.3speak.tv/embed?v=
+	// (the latter is what some clients paste) — with or without the play. subdomain.
+	let threespk_embed_reg = /\[!\[[^\]]*\]\([^)]+\)\]\(https?:\/\/(?:play\.)?3speak\.tv\/(?:watch|embed)\?v=([\w.-]+\/[\w.-]+)\)/ig;
 	report_content = report_content.replace(threespk_embed_reg, (match, v) => {
 		return stashResult(`<div class="video-container"><iframe src="https://play.3speak.tv/watch?v=${v}&mode=iframe&autoplay=false&layout=desktop" scrolling="no" frameborder="0" allowfullscreen></iframe></div>`);
 	});
 
-	let threespk_raw_reg = /(^|\s)(https?:\/\/3speak\.tv\/watch\?v=([\w.-]+\/[\w.-]+))/ig;
+	let threespk_raw_reg = /(^|\s)(https?:\/\/(?:play\.)?3speak\.tv\/(?:watch|embed)\?v=([\w.-]+\/[\w.-]+))/ig;
 	report_content = report_content.replace(threespk_raw_reg, (match, prefix, url, v) => {
 		return prefix + stashResult(`<div class="video-container"><iframe src="https://play.3speak.tv/watch?v=${v}&mode=iframe&autoplay=false&layout=desktop" scrolling="no" frameborder="0" allowfullscreen></iframe></div>`);
 	});

--- a/test/unit/plugins/vue-custom.spec.js
+++ b/test/unit/plugins/vue-custom.spec.js
@@ -117,10 +117,18 @@ describe('plugins/vue-custom global helpers', () => {
       expect(html).toContain('youtube.com/embed/dQw4w9WgXcQ')
     })
 
-    it('still renders a 3Speak embed as a trusted iframe', () => {
+    it('still renders a 3Speak watch URL as a trusted iframe', () => {
       const html = clean('https://3speak.tv/watch?v=user/abcdefg')
       expect(html).toContain('<iframe')
       expect(html).toContain('3speak.tv/watch?v=user/abcdefg')
+    })
+
+    it('renders the play.3speak.tv/embed?v= URL form as an embedded player', () => {
+      const html = clean('https://play.3speak.tv/embed?v=dmann/g8uv7nzq')
+      expect(html).toContain('<iframe')
+      // normalised to the canonical iframe player URL (& may be entity-encoded as &amp;)
+      expect(html).toMatch(/play\.3speak\.tv\/watch\?v=dmann\/g8uv7nzq&(?:amp;)?mode=iframe/)
+      expect(html).not.toMatch(/<a[^>]*play\.3speak\.tv\/embed/)
     })
 
     it('still renders @mentions as actifit links', () => {


### PR DESCRIPTION
## Problem
3Speak posts that paste the `https://play.3speak.tv/embed?v=user/id` URL form (e.g. [@dmann's Chanachur post](https://actifit.io/@dmann/viral-chanachur-sellers-ama-31)) rendered as a **plain autolink** instead of the video player. The matchers only recognised `3speak.tv/watch?v=user/id`.

## Fix
Broaden both 3Speak regexes (markdown-thumbnail-wrapped + raw URL) to accept an optional `play.` subdomain and the `embed` path:

```
was: https?:\/\/3speak\.tv\/watch\?v=([\w.-]+\/[\w.-]+)
new: https?:\/\/(?:play\.)?3speak\.tv\/(?:watch|embed)\?v=([\w.-]+\/[\w.-]+)
```

The captured `v` is normalised into the existing canonical player URL (`https://play.3speak.tv/watch?v=…&mode=iframe&autoplay=false&layout=desktop`), which is already on the trusted-iframe host allow-list.

## Testing
- New regression test for the `play.3speak.tv/embed?v=` form (asserts iframe rendered, not an autolink).
- Verified against @dmann's real post body: player now embeds, raw link gone, all 24 inline images still render.
- **Full suite: 123/123 passing.**

Follow-up to the 1.10.7 stored-XSS release; benefits from the restore-before-sanitize change (the iframe now flows through the host allow-list).