### PR TITLE
fix(explore): stop crash when navigating posts in the modal

### DIFF
--- a/pages/explore.vue
+++ b/pages/explore.vue
@@ -207,26 +207,18 @@
 		  return arr1.length === arr2.length && arr1.every((val, index) => val === arr2[index]);
 		},
 		nextPost (direction){
-		let pstId = this.activePost.pstId;
-		// console.log(pstId);
-		let proceed = false;
-		if (direction < 0){
-			// console.log('move back');
-			if (pstId >= 1){
-				pstId -= 1;
-				proceed = true;
-			}
-		}else{
-			// console.log('move front');
-			if (pstId < this.communityPosts.length){
-				pstId += 1;
-				proceed = true;
-			}
-		}
-		if (proceed){
-			this.communityPosts[pstId].pstId = pstId;
-			this.$store.commit('setActivePost', this.communityPosts[pstId]);
-		}
+		let pstId = this.activePost && this.activePost.pstId;
+		// On /explore the posts are rendered by <CommunityContent> children, each
+		// owning its own posts array, so this page's communityPosts stays empty.
+		// Bounds-check the target and bail cleanly rather than indexing an empty /
+		// out-of-range array and crashing ("Cannot set properties of undefined").
+		if (typeof pstId !== 'number') return;
+		const target = direction < 0 ? pstId - 1 : pstId + 1;
+		if (target < 0 || target >= this.communityPosts.length) return;
+		const post = this.communityPosts[target];
+		if (!post) return;
+		post.pstId = target;
+		this.$store.commit('setActivePost', post);
 	  },
 	  initiateNewPost($event) {
 		$event.preventDefault();


### PR DESCRIPTION
## Problem
On `/explore`, clicking **Previous Post** (and, silently, **Next Post**) in the post modal threw `Cannot set properties of undefined (setting 'pstId')` and broke the page render.

## Root cause
`/explore` renders its posts through `<CommunityContent>` children (the inline grid in `explore.vue` is commented out), each of which owns its **own** `communityPosts` array and assigns each `<Post>` a `pstId` index into that child array. But the modal at `explore.vue` is wired to **explore.vue's** `nextPost` / `this.communityPosts` — and that array is declared `[]` and never populated. So:

- **Previous** (`nextPost(-1)`): `pstId >= 1` passes → decrement → `this.communityPosts[pstId]` is `undefined` → `undefined.pstId = …` → crash.
- **Next** (`nextPost(1)`): `pstId < 0` never true → silently does nothing.

## Fix
Bounds-check the target index and bail cleanly instead of indexing an empty/out-of-range array. Also fixes a latent off-by-one (the forward guard allowed stepping one past the last element even when the array *was* populated).

## Scope / follow-up
This **stops the crash** (Previous/Next become safe no-ops on `/explore`). It does **not** make the buttons actually navigate there — the posts live in the per-community `CommunityContent` lists, so real Previous/Next navigation on `/explore` needs those lists wired to the modal. Happy to do that as a separate enhancement if wanted.

Pre-existing bug, unrelated to the recent XSS / 3Speak work.