### PR TITLE
feat(explore): make modal Previous/Next navigate per-community posts

### DIFF
--- a/components/CommunityContent.vue
+++ b/components/CommunityContent.vue
@@ -125,6 +125,25 @@
 		  this.reFetchCommunityPosts();
 		}
 	  },
+	  // Modal Previous/Next navigation for the shared post modal on /explore.
+	  // The active post is located in THIS community's list by author+permlink
+	  // (pstId can't be trusted across the multiple community lists on the page).
+	  // Returns true when this community owns the post — including at a list
+	  // boundary — so the caller stops probing other communities; false means
+	  // "not mine, keep looking".
+	  navigateFrom(activePost, direction) {
+		if (!activePost) return false;
+		const idx = this.communityPosts.findIndex(
+		  p => p.author === activePost.author && p.permlink === activePost.permlink
+		);
+		if (idx === -1) return false;
+		const target = idx + (direction < 0 ? -1 : 1);
+		if (target < 0 || target >= this.communityPosts.length) return true; // owned, but at edge
+		const post = this.communityPosts[target];
+		post.pstId = target;
+		this.$store.commit('setActivePost', post);
+		return true;
+	  },
 	  nextPost (direction){
 		let pstId = this.activePost.pstId;
 		console.log(pstId);

--- a/pages/explore.vue
+++ b/pages/explore.vue
@@ -44,7 +44,7 @@
 	  </div>
 
 		<div v-for="(community, index) in selCommunities" :key="index" :community="community">
-			<CommunityContent :community='community[0]' :type="type" />
+			<CommunityContent ref="communityContents" :community='community[0]' :type="type" />
 		</div>
 
       <!-- show listing when loaded -->
@@ -207,18 +207,18 @@
 		  return arr1.length === arr2.length && arr1.every((val, index) => val === arr2[index]);
 		},
 		nextPost (direction){
-		let pstId = this.activePost && this.activePost.pstId;
-		// On /explore the posts are rendered by <CommunityContent> children, each
-		// owning its own posts array, so this page's communityPosts stays empty.
-		// Bounds-check the target and bail cleanly rather than indexing an empty /
-		// out-of-range array and crashing ("Cannot set properties of undefined").
-		if (typeof pstId !== 'number') return;
-		const target = direction < 0 ? pstId - 1 : pstId + 1;
-		if (target < 0 || target >= this.communityPosts.length) return;
-		const post = this.communityPosts[target];
-		if (!post) return;
-		post.pstId = target;
-		this.$store.commit('setActivePost', post);
+		// Posts on /explore live in the per-community <CommunityContent> children,
+		// not in this page's (empty) communityPosts. Delegate to whichever child
+		// owns the active post so Previous/Next navigates within that community's
+		// list. The first child that owns the post handles it (and stops the probe).
+		const active = this.activePost;
+		if (!active) return;
+		const children = [].concat(this.$refs.communityContents || []);
+		for (const child of children) {
+			if (child && typeof child.navigateFrom === 'function' && child.navigateFrom(active, direction)) {
+				return;
+			}
+		}
 	  },
 	  initiateNewPost($event) {
 		$event.preventDefault();

--- a/test/unit/components/CommunityContent.spec.js
+++ b/test/unit/components/CommunityContent.spec.js
@@ -1,0 +1,61 @@
+// Heavy chain libs are imported transitively by child components; stub them so
+// the SFC options object loads. We only exercise the pure navigateFrom logic.
+jest.mock('steem', () => ({ api: { setOptions: jest.fn() } }))
+jest.mock('dsteem', () => ({ Client: jest.fn() }))
+jest.mock('hive-auth-wrapper', () => ({ broadcast: jest.fn(), authenticate: jest.fn() }))
+
+import CommunityContent from '@/components/CommunityContent.vue'
+
+const { navigateFrom } = CommunityContent.methods
+
+const posts = () => ([
+  { author: 'alice', permlink: 'p0' },
+  { author: 'bob', permlink: 'p1' },
+  { author: 'carol', permlink: 'p2' }
+])
+
+function ctx (list) {
+  return { communityPosts: list, $store: { commit: jest.fn() } }
+}
+
+describe('components/CommunityContent navigateFrom (modal Prev/Next)', () => {
+  it('moves to the next post within this community', () => {
+    const c = ctx(posts())
+    const handled = navigateFrom.call(c, { author: 'bob', permlink: 'p1' }, 1)
+    expect(handled).toBe(true)
+    expect(c.$store.commit).toHaveBeenCalledWith('setActivePost', expect.objectContaining({ author: 'carol', permlink: 'p2', pstId: 2 }))
+  })
+
+  it('moves to the previous post within this community', () => {
+    const c = ctx(posts())
+    const handled = navigateFrom.call(c, { author: 'bob', permlink: 'p1' }, -1)
+    expect(handled).toBe(true)
+    expect(c.$store.commit).toHaveBeenCalledWith('setActivePost', expect.objectContaining({ author: 'alice', permlink: 'p0', pstId: 0 }))
+  })
+
+  it('owns the post but does NOT move past the last item (no crash, no commit)', () => {
+    const c = ctx(posts())
+    const handled = navigateFrom.call(c, { author: 'carol', permlink: 'p2' }, 1)
+    expect(handled).toBe(true) // owned -> caller stops probing other communities
+    expect(c.$store.commit).not.toHaveBeenCalled()
+  })
+
+  it('owns the post but does NOT move before the first item', () => {
+    const c = ctx(posts())
+    const handled = navigateFrom.call(c, { author: 'alice', permlink: 'p0' }, -1)
+    expect(handled).toBe(true)
+    expect(c.$store.commit).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the post is not in this community (keep probing)', () => {
+    const c = ctx(posts())
+    const handled = navigateFrom.call(c, { author: 'dave', permlink: 'x9' }, 1)
+    expect(handled).toBe(false)
+    expect(c.$store.commit).not.toHaveBeenCalled()
+  })
+
+  it('returns false for a null active post', () => {
+    const c = ctx(posts())
+    expect(navigateFrom.call(c, null, 1)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What
Builds real Previous/Next navigation for the post modal on `/explore`. Follow-up to the crash fix (#297), which made the buttons safe no-ops — this makes them actually navigate.

## Why it was broken
`/explore` renders posts through per-community `<CommunityContent>` children, each owning its own posts array. The page-level modal had no access to those arrays, so Prev/Next couldn't navigate.

## How
- **CommunityContent** gains `navigateFrom(activePost, direction)`: finds the active post in its own list by `author`+`permlink` (pstId isn't unique across the multiple community lists), moves within that list honoring boundaries, and returns `true` when it owns the post so the caller stops probing other communities.
- **explore.vue** `nextPost` delegates to its `<CommunityContent>` refs; the community that owns the active post handles the move.

Navigation stays **within the community you were browsing**, which matches how `/explore` is laid out (horizontal per-community rows).

## Safety — other screens untouched
Only `explore.vue` and `CommunityContent.vue` change, and `CommunityContent` is used **solely** by `/explore` (verified). Every other screen (search, blog, comments, tag, videos, activity, communities) keeps its own existing `nextPost` — no shared code touched.

## Tests
- 6 new `navigateFrom` unit tests (next/prev, both boundaries, not-owned, null).
- **Full suite: 129/129 passing.**
- Verified `/explore` compiles and loads on local dev.