### PR TITLE
Release 1.10.8: 3Speak embed format, /explore modal crash fix + navigation

### DIFF
--- a/components/CommunityContent.vue
+++ b/components/CommunityContent.vue
@@ -125,6 +125,25 @@
 		  this.reFetchCommunityPosts();
 		}
 	  },
+	  // Modal Previous/Next navigation for the shared post modal on /explore.
+	  // The active post is located in THIS community's list by author+permlink
+	  // (pstId can't be trusted across the multiple community lists on the page).
+	  // Returns true when this community owns the post — including at a list
+	  // boundary — so the caller stops probing other communities; false means
+	  // "not mine, keep looking".
+	  navigateFrom(activePost, direction) {
+		if (!activePost) return false;
+		const idx = this.communityPosts.findIndex(
+		  p => p.author === activePost.author && p.permlink === activePost.permlink
+		);
+		if (idx === -1) return false;
+		const target = idx + (direction < 0 ? -1 : 1);
+		if (target < 0 || target >= this.communityPosts.length) return true; // owned, but at edge
+		const post = this.communityPosts[target];
+		post.pstId = target;
+		this.$store.commit('setActivePost', post);
+		return true;
+	  },
 	  nextPost (direction){
 		let pstId = this.activePost.pstId;
 		console.log(pstId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actifit-landingpage",
-      "version": "1.10.7",
+      "version": "1.10.8",
       "hasInstallScript": true,
       "dependencies": {
         "@blurtfoundation/blurtjs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.10.7",
+  "version": "1.10.8",
   "description": "Actifit is an innovative dapp that aims to incentivize fitness and healthy lifestyle via rewarding daily activity.",
   "author": "mktcode",
   "private": true,

--- a/pages/explore.vue
+++ b/pages/explore.vue
@@ -44,7 +44,7 @@
 	  </div>
 
 		<div v-for="(community, index) in selCommunities" :key="index" :community="community">
-			<CommunityContent :community='community[0]' :type="type" />
+			<CommunityContent ref="communityContents" :community='community[0]' :type="type" />
 		</div>
 
       <!-- show listing when loaded -->
@@ -207,18 +207,18 @@
 		  return arr1.length === arr2.length && arr1.every((val, index) => val === arr2[index]);
 		},
 		nextPost (direction){
-		let pstId = this.activePost && this.activePost.pstId;
-		// On /explore the posts are rendered by <CommunityContent> children, each
-		// owning its own posts array, so this page's communityPosts stays empty.
-		// Bounds-check the target and bail cleanly rather than indexing an empty /
-		// out-of-range array and crashing ("Cannot set properties of undefined").
-		if (typeof pstId !== 'number') return;
-		const target = direction < 0 ? pstId - 1 : pstId + 1;
-		if (target < 0 || target >= this.communityPosts.length) return;
-		const post = this.communityPosts[target];
-		if (!post) return;
-		post.pstId = target;
-		this.$store.commit('setActivePost', post);
+		// Posts on /explore live in the per-community <CommunityContent> children,
+		// not in this page's (empty) communityPosts. Delegate to whichever child
+		// owns the active post so Previous/Next navigates within that community's
+		// list. The first child that owns the post handles it (and stops the probe).
+		const active = this.activePost;
+		if (!active) return;
+		const children = [].concat(this.$refs.communityContents || []);
+		for (const child of children) {
+			if (child && typeof child.navigateFrom === 'function' && child.navigateFrom(active, direction)) {
+				return;
+			}
+		}
 	  },
 	  initiateNewPost($event) {
 		$event.preventDefault();

--- a/pages/explore.vue
+++ b/pages/explore.vue
@@ -207,26 +207,18 @@
 		  return arr1.length === arr2.length && arr1.every((val, index) => val === arr2[index]);
 		},
 		nextPost (direction){
-		let pstId = this.activePost.pstId;
-		// console.log(pstId);
-		let proceed = false;
-		if (direction < 0){
-			// console.log('move back');
-			if (pstId >= 1){
-				pstId -= 1;
-				proceed = true;
-			}
-		}else{
-			// console.log('move front');
-			if (pstId < this.communityPosts.length){
-				pstId += 1;
-				proceed = true;
-			}
-		}
-		if (proceed){
-			this.communityPosts[pstId].pstId = pstId;
-			this.$store.commit('setActivePost', this.communityPosts[pstId]);
-		}
+		let pstId = this.activePost && this.activePost.pstId;
+		// On /explore the posts are rendered by <CommunityContent> children, each
+		// owning its own posts array, so this page's communityPosts stays empty.
+		// Bounds-check the target and bail cleanly rather than indexing an empty /
+		// out-of-range array and crashing ("Cannot set properties of undefined").
+		if (typeof pstId !== 'number') return;
+		const target = direction < 0 ? pstId - 1 : pstId + 1;
+		if (target < 0 || target >= this.communityPosts.length) return;
+		const post = this.communityPosts[target];
+		if (!post) return;
+		post.pstId = target;
+		this.$store.commit('setActivePost', post);
 	  },
 	  initiateNewPost($event) {
 		$event.preventDefault();

--- a/plugins/vue-custom.js
+++ b/plugins/vue-custom.js
@@ -356,12 +356,14 @@ Vue.prototype.$cleanBody = function (report_content, full_cleanup, no_media){
 	});
 
 	// Process 3Speak
-	let threespk_embed_reg = /\[!\[[^\]]*\]\([^)]+\)\]\(https?:\/\/3speak\.tv\/watch\?v=([\w.-]+\/[\w.-]+)\)/ig;
+	// Accept both URL shapes — 3speak.tv/watch?v= and play.3speak.tv/embed?v=
+	// (the latter is what some clients paste) — with or without the play. subdomain.
+	let threespk_embed_reg = /\[!\[[^\]]*\]\([^)]+\)\]\(https?:\/\/(?:play\.)?3speak\.tv\/(?:watch|embed)\?v=([\w.-]+\/[\w.-]+)\)/ig;
 	report_content = report_content.replace(threespk_embed_reg, (match, v) => {
 		return stashResult(`<div class="video-container"><iframe src="https://play.3speak.tv/watch?v=${v}&mode=iframe&autoplay=false&layout=desktop" scrolling="no" frameborder="0" allowfullscreen></iframe></div>`);
 	});
 
-	let threespk_raw_reg = /(^|\s)(https?:\/\/3speak\.tv\/watch\?v=([\w.-]+\/[\w.-]+))/ig;
+	let threespk_raw_reg = /(^|\s)(https?:\/\/(?:play\.)?3speak\.tv\/(?:watch|embed)\?v=([\w.-]+\/[\w.-]+))/ig;
 	report_content = report_content.replace(threespk_raw_reg, (match, prefix, url, v) => {
 		return prefix + stashResult(`<div class="video-container"><iframe src="https://play.3speak.tv/watch?v=${v}&mode=iframe&autoplay=false&layout=desktop" scrolling="no" frameborder="0" allowfullscreen></iframe></div>`);
 	});

--- a/test/unit/components/CommunityContent.spec.js
+++ b/test/unit/components/CommunityContent.spec.js
@@ -1,0 +1,61 @@
+// Heavy chain libs are imported transitively by child components; stub them so
+// the SFC options object loads. We only exercise the pure navigateFrom logic.
+jest.mock('steem', () => ({ api: { setOptions: jest.fn() } }))
+jest.mock('dsteem', () => ({ Client: jest.fn() }))
+jest.mock('hive-auth-wrapper', () => ({ broadcast: jest.fn(), authenticate: jest.fn() }))
+
+import CommunityContent from '@/components/CommunityContent.vue'
+
+const { navigateFrom } = CommunityContent.methods
+
+const posts = () => ([
+  { author: 'alice', permlink: 'p0' },
+  { author: 'bob', permlink: 'p1' },
+  { author: 'carol', permlink: 'p2' }
+])
+
+function ctx (list) {
+  return { communityPosts: list, $store: { commit: jest.fn() } }
+}
+
+describe('components/CommunityContent navigateFrom (modal Prev/Next)', () => {
+  it('moves to the next post within this community', () => {
+    const c = ctx(posts())
+    const handled = navigateFrom.call(c, { author: 'bob', permlink: 'p1' }, 1)
+    expect(handled).toBe(true)
+    expect(c.$store.commit).toHaveBeenCalledWith('setActivePost', expect.objectContaining({ author: 'carol', permlink: 'p2', pstId: 2 }))
+  })
+
+  it('moves to the previous post within this community', () => {
+    const c = ctx(posts())
+    const handled = navigateFrom.call(c, { author: 'bob', permlink: 'p1' }, -1)
+    expect(handled).toBe(true)
+    expect(c.$store.commit).toHaveBeenCalledWith('setActivePost', expect.objectContaining({ author: 'alice', permlink: 'p0', pstId: 0 }))
+  })
+
+  it('owns the post but does NOT move past the last item (no crash, no commit)', () => {
+    const c = ctx(posts())
+    const handled = navigateFrom.call(c, { author: 'carol', permlink: 'p2' }, 1)
+    expect(handled).toBe(true) // owned -> caller stops probing other communities
+    expect(c.$store.commit).not.toHaveBeenCalled()
+  })
+
+  it('owns the post but does NOT move before the first item', () => {
+    const c = ctx(posts())
+    const handled = navigateFrom.call(c, { author: 'alice', permlink: 'p0' }, -1)
+    expect(handled).toBe(true)
+    expect(c.$store.commit).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the post is not in this community (keep probing)', () => {
+    const c = ctx(posts())
+    const handled = navigateFrom.call(c, { author: 'dave', permlink: 'x9' }, 1)
+    expect(handled).toBe(false)
+    expect(c.$store.commit).not.toHaveBeenCalled()
+  })
+
+  it('returns false for a null active post', () => {
+    const c = ctx(posts())
+    expect(navigateFrom.call(c, null, 1)).toBe(false)
+  })
+})

--- a/test/unit/plugins/vue-custom.spec.js
+++ b/test/unit/plugins/vue-custom.spec.js
@@ -117,10 +117,18 @@ describe('plugins/vue-custom global helpers', () => {
       expect(html).toContain('youtube.com/embed/dQw4w9WgXcQ')
     })
 
-    it('still renders a 3Speak embed as a trusted iframe', () => {
+    it('still renders a 3Speak watch URL as a trusted iframe', () => {
       const html = clean('https://3speak.tv/watch?v=user/abcdefg')
       expect(html).toContain('<iframe')
       expect(html).toContain('3speak.tv/watch?v=user/abcdefg')
+    })
+
+    it('renders the play.3speak.tv/embed?v= URL form as an embedded player', () => {
+      const html = clean('https://play.3speak.tv/embed?v=dmann/g8uv7nzq')
+      expect(html).toContain('<iframe')
+      // normalised to the canonical iframe player URL (& may be entity-encoded as &amp;)
+      expect(html).toMatch(/play\.3speak\.tv\/watch\?v=dmann\/g8uv7nzq&(?:amp;)?mode=iframe/)
+      expect(html).not.toMatch(/<a[^>]*play\.3speak\.tv\/embed/)
     })
 
     it('still renders @mentions as actifit links', () => {


### PR DESCRIPTION
Promotes to production:
- feat(explore): per-community Previous/Next navigation in the post modal (#298)
- fix(explore): stop crash when navigating posts in the modal (#297)
- fix(3speak): embed play.3speak.tv/embed?v= URL form as a player (#296)
- chore: bump version to 1.10.8 (#299)

Auto-deploys to actifit.io on merge to master.