### PR TITLE
fix(build): sync package-lock undici to unblock npm ci deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22284,10 +22284,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
-      "license": "MIT",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "optional": true,
       "peer": true,
       "engines": {
@@ -40112,9 +40111,9 @@
       }
     },
     "undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
       "optional": true,
       "peer": true
     },


### PR DESCRIPTION
DO deploy failed with npm ci EUSAGE (lockfile undici@6.26.0 vs package.json ^6.23.0 -> 6.27.0). Regenerated lockfile with npm 8.19.4 (DO's npm), lockfileVersion 2 preserved, only undici 6.26.0->6.27.0. Unblocks the 1.10.8 deploy.