### PR TITLE
chore: add Dependabot grouped-updates config + PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Dependabot configuration
+# Groups related dependency updates into a few combined PRs (instead of one PR
+# per package) and caps how many are open at once, so the lockfile churn and PR
+# flood stay under control. Major-version bumps are intentionally left ungrouped
+# so they get their own PR and a careful review.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      development-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(dev-deps)"


### PR DESCRIPTION
## What
Adds `.github/dependabot.yml` so Dependabot **groups** minor/patch npm updates into a few combined PRs (production and dev deps separately) and **caps open PRs at 5**, instead of opening one PR per package.

## Why
The repo currently has **19 open Dependabot PRs** (and previously accumulated 25 stale ones). Because each PR edits `package-lock.json`, merging one forces the rest to rebase, so most go stale rather than getting merged. Grouping + a limit means a handful of reviewable PRs, far less lockfile conflict, and Dependabot auto-closes obsoleted ones.

- Major-version bumps stay **ungrouped** → own PR + careful review.
- Weekly schedule (Mondays).

## After this merges
Dependabot will re-batch the current outstanding updates into the grouped PRs on its next run; we then review + merge the security-relevant ones CI-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)