### PR TITLE
chore(deps): remove unused @ffmpeg deps + ignore vue-steemconnect in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    ignore:
+      # Heavily customized locally via a patch-package patch pinned to 0.3.1
+      # (adds the stdLogin login-type flag the app depends on). Upgrading to
+      # 0.4.x only re-does the sc2-sdk->steemconnect migration we already
+      # patched in, breaks the pinned patch, and drops our stdLogin change.
+      - dependency-name: "vue-steemconnect"
     groups:
       production-minor-patch:
         dependency-type: "production"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "hasInstallScript": true,
       "dependencies": {
         "@blurtfoundation/blurtjs": "^1.0.0",
-        "@ffmpeg/core": "^0.10.0",
-        "@ffmpeg/ffmpeg": "^0.10.1",
         "@google/generative-ai": "^0.24.1",
         "@hiveio/dhive": "^0.14.1",
         "@hiveio/hive-js": "^2.0.1",
@@ -3575,25 +3573,6 @@
         "@ethersproject/logger": "^5.8.0",
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/strings": "^5.8.0"
-      }
-    },
-    "node_modules/@ffmpeg/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-qunWJl5PezpXEm31tb8Qu5z37B5KVA1VYZCpXchMhuAb3X9T7PuE3SlhOwphEoRhzaOa3lpofDfzihAUMFaVPQ=="
-    },
-    "node_modules/@ffmpeg/ffmpeg": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.10.1.tgz",
-      "integrity": "sha512-ChQkH7Rh57hmVo1LhfQFibWX/xqneolJKSwItwZdKPcLZuKigtYAYDIvB55pDfP17VtR1R77SxgkB2/UApB+Og==",
-      "dependencies": {
-        "is-url": "^1.2.4",
-        "node-fetch": "^2.6.1",
-        "regenerator-runtime": "^0.13.7",
-        "resolve-url": "^0.2.1"
-      },
-      "engines": {
-        "node": ">=12.16.1"
       }
     },
     "node_modules/@gar/promisify": {
@@ -13693,11 +13672,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
-    "node_modules/is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -19964,12 +19938,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
-      "deprecated": "https://github.com/lydell/resolve-url#deprecated"
-    },
     "node_modules/resolve.exports": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
@@ -22284,9 +22252,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "optional": true,
       "peer": true,
       "engines": {
@@ -24473,10 +24441,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.5.tgz",
-      "integrity": "sha512-G0gACQIjFmv7NqpaOAXEpe9nEtRYD6ZCy2Ip/B4EzR08qEwnf/wYJoQd3cjosPdnJsHkeh0j2tzOaIBZIOC1yA==",
-      "license": "MIT",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.7.tgz",
+      "integrity": "sha512-Yp1RXz/2h2qC/Gy7d5mqQcpuCWbXiO6FgYw/jTbSvytZF9wD7fh7od+6WzWR/y9EAnXcJjQZpPkYVmj3T2bj+Q==",
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
@@ -26635,22 +26602,6 @@
         "@ethersproject/logger": "^5.8.0",
         "@ethersproject/properties": "^5.8.0",
         "@ethersproject/strings": "^5.8.0"
-      }
-    },
-    "@ffmpeg/core": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/core/-/core-0.10.0.tgz",
-      "integrity": "sha512-qunWJl5PezpXEm31tb8Qu5z37B5KVA1VYZCpXchMhuAb3X9T7PuE3SlhOwphEoRhzaOa3lpofDfzihAUMFaVPQ=="
-    },
-    "@ffmpeg/ffmpeg": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@ffmpeg/ffmpeg/-/ffmpeg-0.10.1.tgz",
-      "integrity": "sha512-ChQkH7Rh57hmVo1LhfQFibWX/xqneolJKSwItwZdKPcLZuKigtYAYDIvB55pDfP17VtR1R77SxgkB2/UApB+Og==",
-      "requires": {
-        "is-url": "^1.2.4",
-        "node-fetch": "^2.7.0",
-        "regenerator-runtime": "^0.13.7",
-        "resolve-url": "^0.2.1"
       }
     },
     "@gar/promisify": {
@@ -34025,11 +33976,6 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
-    "is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
-    },
     "is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -38416,11 +38362,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
     },
-    "resolve-url": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg=="
-    },
     "resolve.exports": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.1.tgz",
@@ -40111,9 +40052,9 @@
       }
     },
     "undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "optional": true,
       "peer": true
     },
@@ -41828,9 +41769,9 @@
       }
     },
     "ws": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.5.tgz",
-      "integrity": "sha512-G0gACQIjFmv7NqpaOAXEpe9nEtRYD6ZCy2Ip/B4EzR08qEwnf/wYJoQd3cjosPdnJsHkeh0j2tzOaIBZIOC1yA==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.7.tgz",
+      "integrity": "sha512-Yp1RXz/2h2qC/Gy7d5mqQcpuCWbXiO6FgYw/jTbSvytZF9wD7fh7od+6WzWR/y9EAnXcJjQZpPkYVmj3T2bj+Q==",
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
   },
   "dependencies": {
     "@blurtfoundation/blurtjs": "^1.0.0",
-    "@ffmpeg/core": "^0.10.0",
-    "@ffmpeg/ffmpeg": "^0.10.1",
     "@google/generative-ai": "^0.24.1",
     "@hiveio/dhive": "^0.14.1",
     "@hiveio/hive-js": "^2.0.1",


### PR DESCRIPTION
## What
1. **Removes `@ffmpeg/core` + `@ffmpeg/ffmpeg`** — they're declared in `package.json` but **never imported anywhere** in the codebase (zero references outside `package.json`). Dead, heavy WASM deps; pruned from the lockfile too (only their exclusive transitive deps `is-url`/`resolve-url` came out with them).
2. **Ignores `vue-steemconnect` in `.github/dependabot.yml`** — our copy is customized via a `patch-package` patch pinned to **0.3.1** (adds the `stdLogin` login-type flag the app depends on). Upstream 0.4.x only re-does the `sc2-sdk`→`steemconnect` migration we already patched in, and would **break the pinned patch + drop `stdLogin`**. So Dependabot should stop proposing it.

## Why now
Dependabot's grouped PR #341 bundled the useful security bumps (dompurify, sanitize-html, …) together with the `@ffmpeg` 0.12 breaking bump and the unwanted `vue-steemconnect` 0.4.x. After this lands, #341 will be closed so Dependabot re-groups into a clean **security-bumps-only** PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)