### PR TITLE
Fixed user cancellation

### DIFF
--- a/pages/_username/index.vue
+++ b/pages/_username/index.vue
@@ -1031,6 +1031,7 @@ export default {
           this.$processTrxFunc('account_update2', transaction, false),
           timeoutError
         );
+        if (outcome && outcome.error === 'user_cancel') return;
         if (!outcome || !outcome.success) throw new Error((outcome && outcome.error) || this.$t('Save_Error'));
 
         this.userinfo = { ...this.userinfo, posting_json_metadata: transaction.posting_json_metadata };

--- a/test/unit/pages/profile-metadata-update.spec.js
+++ b/test/unit/pages/profile-metadata-update.spec.js
@@ -113,4 +113,28 @@ describe('profile metadata updates', () => {
     expect(context.applyMeasurementSources).not.toHaveBeenCalled()
     expect(context.savingMeasurements).toBe(false)
   })
+
+  it('silently stops saving measurements when the user cancels Keychain', async () => {
+    const context = {
+      user: { account: { name: 'alice' } },
+      userinfo: {},
+      measurementDraft: { weight: '70', weightUnit: 'kg' },
+      measurementSaveError: '',
+      savingMeasurements: false,
+      getLiveProfileMetadata: jest.fn().mockResolvedValue({ profile: {} }),
+      $processTrxFunc: jest.fn().mockResolvedValue({ success: false, error: 'user_cancel' }),
+      applyMeasurementSources: jest.fn(),
+      turnMeasurementsEditOff: jest.fn(),
+      $notify: jest.fn(),
+      $t: key => key
+    }
+
+    await saveMeasurements.call(context)
+
+    expect(context.measurementSaveError).toBe('')
+    expect(context.applyMeasurementSources).not.toHaveBeenCalled()
+    expect(context.turnMeasurementsEditOff).not.toHaveBeenCalled()
+    expect(context.$notify).not.toHaveBeenCalled()
+    expect(context.savingMeasurements).toBe(false)
+  })
 })


### PR DESCRIPTION
user_cancel now exits silently without an error or success notification