### PR TITLE
perf: lazy-load / remove eager third-party scripts (SimpleMDE, AdSense, reCAPTCHA, Sting chat) + debounce user search

### DIFF
--- a/components/AutocompleteUsernameInput.vue
+++ b/components/AutocompleteUsernameInput.vue
@@ -49,14 +49,21 @@ export default {
       showDropdownList: false,
       mentionList: [],
       highlightedIndex: -1,
+      debounceTimer: null,
+      abortController: null,
     };
   },
   methods: {
     async fetchMentions() {
       if (!this.inputValue) return;
+      // Cancel any in-flight request so rapid typing doesn't stack requests
+      // (each request also makes ad/privacy extensions re-run filter checks).
+      if (this.abortController) this.abortController.abort();
+      this.abortController = new AbortController();
       try {
         const response = await axios.get(
-          process.env.hiveApiNode + `/hafbe-api/input-type/${this.inputValue}%25`
+          process.env.hiveApiNode + `/hafbe-api/input-type/${this.inputValue}%25`,
+          { signal: this.abortController.signal }
         );
         const responseData = response.data;
         if (responseData.input_type === 'invalid_input') {
@@ -79,14 +86,23 @@ export default {
         }
 
       } catch (error) {
+        // Ignore aborted (superseded) requests.
+        if (axios.isCancel && axios.isCancel(error)) return;
+        if (error && (error.name === 'CanceledError' || error.name === 'AbortError')) return;
         console.error("Error fetching mentions:", error);
       }
     },
     onInput() {
       if (this.inputValue) {
-        this.fetchMentions(); // Fetch suggestions dynamically
         this.showDropdownList = true;
+        // Debounce so we fire ~1 request after the user pauses typing, not one
+        // per keystroke. Un-debounced, a burst of requests each triggered an
+        // ad/privacy extension's synchronous filter-match against Easylist,
+        // congesting the main thread and freezing the search field for seconds.
+        clearTimeout(this.debounceTimer);
+        this.debounceTimer = setTimeout(() => this.fetchMentions(), 300);
       } else {
+        clearTimeout(this.debounceTimer);
         this.showDropdownList = false;
         this.mentionList = [];
       }
@@ -166,6 +182,10 @@ export default {
   mounted() {
     // Forward the ref to make it accessible via the parent component
     this.$refs.input = this.$refs.inputElement;
+  },
+  beforeDestroy() {
+    clearTimeout(this.debounceTimer);
+    if (this.abortController) this.abortController.abort();
   },
 };
 </script>

--- a/components/LoginModal.vue
+++ b/components/LoginModal.vue
@@ -67,7 +67,10 @@
   // YOUR CURRENT, IMPROVED SCRIPT IS PRESERVED
   import { VueReCaptcha } from 'vue-recaptcha-v3'
   import Vue from 'vue'
-  Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key })
+  // reCAPTCHA is installed lazily (see ensureRecaptcha) when the login modal is
+  // opened — NOT at import time. This component is imported by the always-present
+  // navbar, so a module-level Vue.use() loaded the Google reCAPTCHA script on
+  // every page (including the homepage) and blocked the main thread on load.
   import QRious from 'qrious';
   import { PublicKey, Signature, hash } from '@hiveio/hive-js/lib/auth/ecc';
 
@@ -117,13 +120,14 @@
       $(this.$refs.loginModal).on('show.bs.modal', () => {
         this.originalTitle = document.title;
         document.title = this.$t('Login_actifit');
+        // Load reCAPTCHA only once the user actually opens the login modal.
+        this.ensureRecaptcha();
       });
       $(this.$refs.loginModal).on('hidden.bs.modal', () => {
         document.title = this.originalTitle;
         this.resetForm();
         this.$emit('close');
       });
-      await this.$recaptchaLoaded();
       this.verifyKeychain();
     },
     beforeDestroy() {
@@ -147,14 +151,14 @@
         let acct_data = json.HIVE; let userSC = new Object(); userSC.account = acct_data; this.is_logged_in = true; this.$store.commit('setStdLoginUser', true); localStorage.setItem('acti_login_method', 'hiveauth'); localStorage.setItem('access_token', this.hiveauth_token); localStorage.setItem('expires', this.hiveauth_expire); localStorage.setItem('key', this.hiveauth_key); localStorage.setItem('std_login', true); localStorage.setItem('std_login_name', userSC.account.name); this.$store.commit('steemconnect/login', userSC); this.closeModal(); this.resetForm(); this.$store.dispatch('steemconnect/refreshUser'); this.$store.dispatch('fetchModerators');
       },
       setKeychainLoginStatus (json){
-        if (json && json.success && json.token && json.userdata){ const recaptcha = this.$recaptchaInstance; recaptcha.hideBadge(); let acct_data = json.userdata; let userSC = new Object(); userSC.account = acct_data; this.is_logged_in = true; this.$store.commit('setStdLoginUser', true); localStorage.setItem('access_token', json.token); localStorage.setItem('std_login', true); localStorage.setItem('std_login_name', userSC.account.name); localStorage.setItem('acti_login_method', 'keychain'); this.$store.commit('steemconnect/login', userSC); this.closeModal(); this.resetForm(); this.$store.dispatch('steemconnect/refreshUser'); this.$store.dispatch('fetchModerators'); }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); return; }
+        if (json && json.success && json.token && json.userdata){ const recaptcha = this.$recaptchaInstance; if (recaptcha) recaptcha.hideBadge(); let acct_data = json.userdata; let userSC = new Object(); userSC.account = acct_data; this.is_logged_in = true; this.$store.commit('setStdLoginUser', true); localStorage.setItem('access_token', json.token); localStorage.setItem('std_login', true); localStorage.setItem('std_login_name', userSC.account.name); localStorage.setItem('acti_login_method', 'keychain'); this.$store.commit('steemconnect/login', userSC); this.closeModal(); this.resetForm(); this.$store.dispatch('steemconnect/refreshUser'); this.$store.dispatch('fetchModerators'); }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); return; }
       },
       setUserLoginStatus (json, postingKey) {
-        this.is_logged_in = json.success; if (json.success && json.token){ const recaptcha = this.$recaptchaInstance; recaptcha.hideBadge(); localStorage.setItem('actiToken', json.token); let userSC = new Object(); userSC.account = json.userdata; this.$store.commit('setStdLoginUser', true); this.$store.commit('setChatPostingKey', postingKey); localStorage.setItem('access_token', json.token); localStorage.setItem('std_login', true); localStorage.setItem('std_login_name', userSC.account.name); localStorage.setItem('acti_login_method', ''); this.$store.commit('steemconnect/login', userSC); this.closeModal(); this.resetForm(); this.$store.dispatch('steemconnect/refreshUser'); this.$store.dispatch('fetchModerators'); this.$emit('login-successful'); }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); }
+        this.is_logged_in = json.success; if (json.success && json.token){ const recaptcha = this.$recaptchaInstance; if (recaptcha) recaptcha.hideBadge(); localStorage.setItem('actiToken', json.token); let userSC = new Object(); userSC.account = json.userdata; this.$store.commit('setStdLoginUser', true); this.$store.commit('setChatPostingKey', postingKey); localStorage.setItem('access_token', json.token); localStorage.setItem('std_login', true); localStorage.setItem('std_login_name', userSC.account.name); localStorage.setItem('acti_login_method', ''); this.$store.commit('steemconnect/login', userSC); this.closeModal(); this.resetForm(); this.$store.dispatch('steemconnect/refreshUser'); this.$store.dispatch('fetchModerators'); this.$emit('login-successful'); }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); }
       },
       verifyHiveauth (challenge, data){ const sig = Signature.fromHex(data.challenge); const buf = hash.sha256(challenge, null, 0); return sig.verifyHash(buf, PublicKey.fromString(data.pubkey)); },
 async loginHiveauth (){
-        if (this.$refs["username"].value == ''){ this.error_proceeding = true; this.error_msg = this.$t('login_error'); return; } this.login_in_progress = true; let account = this.$refs["username"].value.trim().toLowerCase(); const APP_META = { name:"actifit", description: process.env.socialSharingTitle, icon:"https://actifit.io/img/actifit_logo.png" }; const auth = { username: account, expire: undefined, key: undefined, }; const status = this.$HAS.status(); let challenge_data = { key_type: "posting", challenge: JSON.stringify({ login: account, ts: Date.now(), }) }; let mainRef = this; this.$HAS.authenticate(auth, APP_META, challenge_data, (message) => { if (message.cmd && message.cmd === 'auth_wait'){ this.hiveauth_wait = true; this.$nextTick(() => { const authPayload = { uuid: message.uuid, account: account, key: message.key, host: 'wss://hive-auth.arcange.eu' }; this.hiveauth_key = message.key; const authUri = `has://auth_req/${btoa(JSON.stringify(authPayload))}`; const qrLinkElement = mainRef.$refs['hiveauth-qr-link']; const qrElement = mainRef.$refs['hiveauth-qr']; const QR = new QRious({ element: qrElement, background: 'white', backgroundAlpha: 0.8, foreground: 'black', size: 200, }); QR.value = authUri; qrLinkElement.href = authUri; }); } }).then(async (message) => { if (message.cmd && message.cmd === 'auth_ack'){ const { data } = message; const { expire, token } = data; const success = this.verifyHiveauth(challenge_data.challenge, data.challenge); this.hiveauth_wait = false; this.hiveauth_expire = expire; this.hiveauth_token = token; if (success){ const recaptcha = this.$recaptchaInstance; recaptcha.hideBadge(); this.login_in_progress = false; try { const acctController = new AbortController(); const acctTimeoutId = setTimeout(() => acctController.abort(), 20000); const acctRes = await fetch('/api/proxy/getAccountData?user='+encodeURIComponent(account)+'&bchain=HIVE', { signal: acctController.signal }); clearTimeout(acctTimeoutId); const acctJson = await acctRes.json(); this.setHiveauthLoginStatus(acctJson); } catch (e) { console.error('HiveAuth account data error:', e); this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); } }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); return; } }else if (message.cmd && message.cmd === 'auth_nack'){ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('auth_rejected_by_user'); return; } }).catch(err => { console.error(err); this.error_proceeding = true; this.error_msg = this.$t('login_error'); this.hiveauth_wait = false; this.login_in_progress = false; });
+        if (this.$refs["username"].value == ''){ this.error_proceeding = true; this.error_msg = this.$t('login_error'); return; } this.login_in_progress = true; let account = this.$refs["username"].value.trim().toLowerCase(); const APP_META = { name:"actifit", description: process.env.socialSharingTitle, icon:"https://actifit.io/img/actifit_logo.png" }; const auth = { username: account, expire: undefined, key: undefined, }; const status = this.$HAS.status(); let challenge_data = { key_type: "posting", challenge: JSON.stringify({ login: account, ts: Date.now(), }) }; let mainRef = this; this.$HAS.authenticate(auth, APP_META, challenge_data, (message) => { if (message.cmd && message.cmd === 'auth_wait'){ this.hiveauth_wait = true; this.$nextTick(() => { const authPayload = { uuid: message.uuid, account: account, key: message.key, host: 'wss://hive-auth.arcange.eu' }; this.hiveauth_key = message.key; const authUri = `has://auth_req/${btoa(JSON.stringify(authPayload))}`; const qrLinkElement = mainRef.$refs['hiveauth-qr-link']; const qrElement = mainRef.$refs['hiveauth-qr']; const QR = new QRious({ element: qrElement, background: 'white', backgroundAlpha: 0.8, foreground: 'black', size: 200, }); QR.value = authUri; qrLinkElement.href = authUri; }); } }).then(async (message) => { if (message.cmd && message.cmd === 'auth_ack'){ const { data } = message; const { expire, token } = data; const success = this.verifyHiveauth(challenge_data.challenge, data.challenge); this.hiveauth_wait = false; this.hiveauth_expire = expire; this.hiveauth_token = token; if (success){ const recaptcha = this.$recaptchaInstance; if (recaptcha) recaptcha.hideBadge(); this.login_in_progress = false; try { const acctController = new AbortController(); const acctTimeoutId = setTimeout(() => acctController.abort(), 20000); const acctRes = await fetch('/api/proxy/getAccountData?user='+encodeURIComponent(account)+'&bchain=HIVE', { signal: acctController.signal }); clearTimeout(acctTimeoutId); const acctJson = await acctRes.json(); this.setHiveauthLoginStatus(acctJson); } catch (e) { console.error('HiveAuth account data error:', e); this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); } }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); return; } }else if (message.cmd && message.cmd === 'auth_nack'){ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('auth_rejected_by_user'); return; } }).catch(err => { console.error(err); this.error_proceeding = true; this.error_msg = this.$t('login_error'); this.hiveauth_wait = false; this.login_in_progress = false; });
       },
       async verifyKeychain () {
         return new Promise((resolve) => { if (window.hive_keychain) { this.keychain = window.hive_keychain; this.keychain.requestHandshake(() => { this.keychain_available = true; resolve(); }); } })
@@ -218,11 +222,18 @@ async loginHiveauth (){
           this.error_msg = this.$t('login_error');
         }
       },
+      // Installs vue-recaptcha-v3 (and loads the Google script) on first use.
+      // Vue.use is idempotent, so calling this repeatedly is safe.
+      ensureRecaptcha () {
+        Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key });
+        return this.$recaptchaLoaded();
+      },
       async proceedLogin () {
         this.captcha_invalid = '';
         this.error_proceeding = false;
         this.error_msg = '';
         if (this.$refs["username"].value == '' || this.$refs["ppkey"].value == ''){ this.error_proceeding = true; this.error_msg = this.$t('login_error'); return; }
+        await this.ensureRecaptcha();
         const token = await this.$recaptcha('login');
         let outc = await fetch('/api/proxy/verifyLoginCaptcha?token='+encodeURIComponent(token));
         let captchaJson = await outc.json();

--- a/components/PostModal.vue
+++ b/components/PostModal.vue
@@ -74,9 +74,6 @@
           <a href="#" v-on:click.prevent="cancelTranslation">{{ $t('click_to_view_original') }}</a>
         </div>
         <SafeRemarkable class="modal-body" :source="displayBody" :options="{ 'html': true, 'breaks': true, 'typographer': true }" ref="remarkableContent"></SafeRemarkable>
-        <div class="modal-body goog-ad-horiz-90">
-          <adsbygoogle ad-slot="5716623705" />
-        </div>
         <div class="main-payment-info col-12" id="modal-footer">
           <div >
             <span><a href="#" @click.prevent="toggleCommentBox()" :title="$t('Reply')"><i

--- a/components/ReportModal.vue
+++ b/components/ReportModal.vue
@@ -63,9 +63,6 @@
         </div>
         <SafeRemarkable class="modal-body" :source="displayBody" ref="remarkableContent"
           :options="{ 'html': true, 'breaks': true, 'typographer': true }"></SafeRemarkable>
-        <div class="modal-body goog-ad-horiz-90">
-          <adsbygoogle ad-slot="5716623705" />
-        </div>
         <div class="col-12 main-payment-info" id="modal-footer">
           <div class="report-modal-prelim-info">
             <span><a href="#" @click.prevent="toggleCommentBox()" :title="$t('Reply')"><i

--- a/components/StingChat.vue
+++ b/components/StingChat.vue
@@ -71,7 +71,8 @@ export default {
       postingKeyError: '',
       postingKeyUsername: null,
       widgetSessionVersion: 0,
-      isBeingDestroyed: false
+      isBeingDestroyed: false,
+      widgetRequested: false
     }
   },
   computed: {
@@ -108,12 +109,10 @@ export default {
     }
   },
   mounted () {
-    this.loadWidgetScript()
-      .then(() => this.initWidget())
-      .catch((error) => {
-        console.error('Unable to load Sting chat:', error)
-        this.widgetError = this.$t('sting_chat_unavailable')
-      })
+    // The Sting chat widget (chat.peakd.com embed — socket.io, uploader, and
+    // other third-party resources) is heavy and gets intercepted by ad/privacy
+    // blockers. Load it lazily on the first chat-open (see toggleWidget) instead
+    // of on every page mount.
   },
   beforeDestroy () {
     this.isBeingDestroyed = true
@@ -167,6 +166,10 @@ export default {
       const sessionVersion = ++this.widgetSessionVersion
       this.teardownWidget()
 
+      // Only rebuild if the user has actually opened chat; otherwise leave the
+      // widget unloaded so it stays off every page's initial load.
+      if (!this.widgetRequested) return
+
       this.$nextTick(() => {
         if (this.isBeingDestroyed || sessionVersion !== this.widgetSessionVersion) return
 
@@ -181,6 +184,22 @@ export default {
             this.widgetError = this.$t('sting_chat_unavailable')
           })
       })
+    },
+    // Loads the Sting script and creates the widget on demand. Idempotent, so
+    // it is safe to call from every entry point (toggle, posting-key submit,
+    // session restart).
+    ensureWidget () {
+      if (this.widget) return Promise.resolve()
+      const sessionVersion = this.widgetSessionVersion
+      return this.loadWidgetScript()
+        .then(() => {
+          if (this.isBeingDestroyed || sessionVersion !== this.widgetSessionVersion) return
+          this.initWidget()
+        })
+        .catch((error) => {
+          console.error('Unable to load Sting chat:', error)
+          this.widgetError = this.$t('sting_chat_unavailable')
+        })
     },
     initWidget () {
       if (this.widget || !this.$refs.widgetContainer) return
@@ -477,7 +496,9 @@ export default {
 
       this.$store.commit('setChatPostingKey', postingKey)
       this.closePostingKeyPrompt()
-      this.$nextTick(() => {
+      this.widgetRequested = true
+      // Load the widget now (initWidget reads the just-set posting key) and show it.
+      this.ensureWidget().then(() => {
         const container = this.$refs.widgetContainer
         if (container) container.hidden = false
       })
@@ -487,6 +508,17 @@ export default {
       const loginMethod = localStorage.getItem('acti_login_method') || 'posting-key'
       if (username && loginMethod === 'posting-key' && !this.chatPostingKey) {
         this.openPostingKeyPrompt()
+        return
+      }
+
+      this.widgetRequested = true
+
+      // First open: load + initialize the widget on demand, then reveal it.
+      if (!this.widget) {
+        this.ensureWidget().then(() => {
+          const container = this.$refs.widgetContainer
+          if (container) container.hidden = false
+        })
         return
       }
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -314,10 +314,6 @@ module.exports = {
     //['@nuxtjs/axios'],
     '@nuxtjs/i18n',
     '@nuxtjs/proxy',
-    ['@nuxtjs/google-adsense', {
-      id: 'ca-pub-2770948859841315',
-      pageLevelAds: true
-    }],
   ],
 
   // Proxy configuration to bypass CORS during local development

--- a/pages/_tag/posts/index.vue
+++ b/pages/_tag/posts/index.vue
@@ -41,9 +41,6 @@
               :pstId="(iterx - 1) * splitFactor + (itery - 1)" />
           </div>
           <!--<div class="col-md-6 col-lg-12 mb-4" v-if="(iterx - 1) < inlineAds">
-				<client-only>
-				<adsbygoogle ad-slot="7038919015" ad-format="fluid" ad-layout-key="-fb+5w+4e-db+86"/>
-				</client-only>
 			</div>-->
         </div>
       </div>

--- a/pages/_username/blog/index.vue
+++ b/pages/_username/blog/index.vue
@@ -47,9 +47,6 @@
 			  :key="filteredUserPosts[(iterx - 1) * splitFactor + (itery - 1)].author + '-' + filteredUserPosts[(iterx - 1) * splitFactor + (itery - 1)].permlink" />
           </div>
           <!--<div class="col-md-6 col-lg-12 mb-4" v-if="(iterx - 1) < inlineAds">
-				<client-only>
-				<adsbygoogle ad-slot="7038919015" ad-format="fluid" ad-layout-key="-fb+5w+4e-db+86"/>
-				</client-only>
 			</div>-->
         </div>
       </div>

--- a/pages/_username/comments/index.vue
+++ b/pages/_username/comments/index.vue
@@ -39,9 +39,6 @@
 				<Post v-if="(iterx - 1) * splitFactor + (itery - 1) < userComments.length" :post="userComments[(iterx - 1) * splitFactor + (itery - 1)]" :displayUsername="username" :pstId="(iterx - 1) * splitFactor + (itery - 1)"/>
 			</div>
 			<!--<div class="col-md-6 col-lg-4 mb-4" v-if="(iterx - 1) < inlineAds">
-				<client-only>
-				<adsbygoogle ad-slot="7038919015" ad-format="fluid" ad-layout-key="-fb+5w+4e-db+86"/>
-				</client-only>
 			</div>-->
 		</div>
       </div>

--- a/pages/activity/_username/index.vue
+++ b/pages/activity/_username/index.vue
@@ -24,9 +24,6 @@
 				<Report v-if="(iterx - 1) * splitFactor + (itery - 1) < userReports.length" :report="userReports[(iterx - 1) * splitFactor + (itery - 1)]" :rptId="(iterx - 1) * splitFactor + (itery - 1)" :key="userReports[(iterx - 1) * splitFactor + (itery - 1)].author + '-' + userReports[(iterx - 1) * splitFactor + (itery - 1)].permlink"/>
 			</div>
 			<!--<div class="col-md-6 col-lg-4 mb-4" v-if="(iterx - 1) < inlineAds">
-				<client-only>
-				<adsbygoogle ad-slot="7038919015" ad-format="fluid" ad-layout-key="-fb+5w+4e-db+86"/>
-				</client-only>
 			</div>-->
 		</div>
       </div>

--- a/pages/communities/index.vue
+++ b/pages/communities/index.vue
@@ -47,9 +47,6 @@
 				@update-community="updateCommunity"/>
 			</div>
 			<!--<div class="col-md-6 col-lg-12 mb-4" v-if="(iterx - 1) < inlineAds">
-				<client-only>
-				<adsbygoogle ad-slot="7038919015" ad-format="fluid" ad-layout-key="-fb+5w+4e-db+86"/>
-				</client-only>
 			</div>
 		</div>-->
       </div>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -89,7 +89,9 @@
   //import {keychain, isKeychainInstalled, hasKeychainBeenUsed} from '@hiveio/keychain'
 
   import Vue from 'vue'
-  Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key })
+  // reCAPTCHA is installed lazily in mounted() so this page's module has no
+  // import-time side effect (a module-level Vue.use loaded reCAPTCHA on other
+  // pages, e.g. the homepage, blocking the main thread).
 
   //QR display for hive auth
   import QRious from 'qrious';
@@ -173,9 +175,8 @@
 		} catch (e) {
 		  console.log(e);
 		}*/
-		console.log('load recaptcha')
+		Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key })
 		await this.$recaptchaLoaded()
-		console.log('complete')
 		this.verifyKeychain();
 	},
 	methods: {

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -374,7 +374,8 @@ import { VueReCaptcha } from 'vue-recaptcha-v3'
 import { mapGetters } from 'vuex'
 import Vue from 'vue'
 
-Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key })
+// reCAPTCHA is installed lazily in mounted() so this module has no import-time
+// side effect (a module-level Vue.use loaded reCAPTCHA on other pages too).
 
 export default {
   head() {
@@ -519,6 +520,7 @@ export default {
     this.$store.dispatch('fetchUserRank')
     this.$store.dispatch('fetchReferrals')
 
+    Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key })
     await this.$recaptchaLoaded()
 
   },

--- a/plugins/simplemde-async.js
+++ b/plugins/simplemde-async.js
@@ -1,0 +1,11 @@
+// Lazy-loaded wrapper for the SimpleMDE editor.
+//
+// SimpleMDE bundles CodeMirror and is a very heavy (~2.9MB) dependency. Keeping
+// its JS + CSS here, behind a dynamic import(), lets webpack code-split it into
+// its own chunk that is only fetched when a <vue-simplemde> component actually
+// renders — instead of shipping it in the shared bundle that loads on every
+// route (including the homepage, which has no editor).
+import VueSimplemde from 'vue-simplemde'
+import 'simplemde/dist/simplemde.min.css'
+
+export default VueSimplemde

--- a/plugins/vue-simplemde.js
+++ b/plugins/vue-simplemde.js
@@ -1,6 +1,12 @@
 import Vue from 'vue'
-import VueSimplemde from 'vue-simplemde'
-import 'simplemde/dist/simplemde.min.css'
 
-//Vue.use(VueSimplemde)
-Vue.component('vue-simplemde', VueSimplemde)
+// SimpleMDE (+ CodeMirror) is a ~2.9MB dependency. It was previously imported
+// synchronously and registered as a global component, which pulled the whole
+// editor into the shared bundle loaded on EVERY route — including the homepage,
+// which never renders an editor. Parsing/evaluating that chunk blocked the main
+// thread for ~1.3s on load (the "page loads then freezes for a few seconds" bug).
+//
+// Register it as an ASYNC global component instead: the editor chunk is only
+// fetched when a <vue-simplemde> is actually rendered. (At present nothing renders
+// it, so it is never loaded at all.)
+Vue.component('vue-simplemde', () => import(/* webpackChunkName: "simplemde-editor" */ './simplemde-async.js'))


### PR DESCRIPTION
## What

Several heavy or dead third-party assets were loaded on **every page** even when unused, inflating the initial critical path and (as a side effect) giving ad/privacy blockers like Malwarebytes / uBlock more to filter on each load. This lazy-loads or removes them.

### Changes
- **SimpleMDE / CodeMirror** — `plugins/vue-simplemde.js` globally registered a **~2.9 MB** editor bundle on every page though nothing renders it (dead weight). Switched to an async component (`plugins/simplemde-async.js`) so it code-splits into a lazy chunk.
- **AdSense** — removed `@nuxtjs/google-adsense` (dropped long ago) plus the leftover `<adsbygoogle>` slots in `PostModal`/`ReportModal` and the activity/community/tag/blog/comments list pages.
- **reCAPTCHA** — `LoginModal.vue`, `pages/login.vue`, `pages/signup.vue` each did a **module-level** `Vue.use(VueReCaptcha)` that loaded the Google reCAPTCHA script on every page (LoginModal is in the navbar → all pages). Now installed **lazily** on modal-open / page-mount.
- **Sting chat** — the `chat.peakd.com` widget (socket.io, uploader, embed resources) loaded on **every page mount**. Deferred to **first chat-open**, preserving the login/logout/account-switch session handling from #312.
- **Find-Users autocomplete** (`AutocompleteUsernameInput.vue`) — was firing an API request **per keystroke** with no debounce/cancellation. Now **debounced (300 ms) + cancels in-flight requests**.

## Verification
Confirmed on a **production build** (`nuxt build` + `start`):
- Homepage no longer requests **reCAPTCHA**, **AdSense**, or the **Sting embed** on load.
- SimpleMDE/CodeMirror no longer present in any homepage chunk (~2.9 MB off the critical path).
- Post/report modals render with **no empty ad gaps** and no `Unknown custom element: <adsbygoogle>` warnings.

## ⚠️ QA needed before merge (couldn't be verified headlessly)
These touch **auth and chat** flows — please smoke-test in a real browser:
- **Login** via **Keychain / HiveAuth / posting-key** — login modal, `/login`, `/signup`.
- **Sting chat** — opens on first click, send/receive works, re-initializes on account switch (posting-key + Keychain).
- **Find Users** search still suggests usernames (now debounced).

## Notes
- Branch name (`perf/lazy-load-simplemde`) predates the wider scope.
- Rebased on latest `develop` (includes #354/#355/#357); builds clean; no conflicts.
- Real-world payoff (less work for users' ad/privacy blockers) only shows once deployed to actifit.io.
