### PR TITLE
Fix invalid username loading (account recovery)

### DIFF
--- a/lang/ar_AE.js
+++ b/lang/ar_AE.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'لقد قمت بالتصويت بالفعل على هذا المنشور. هل أنت متأكد أنك تريد تغيير تصويتك؟',
   confirm_delete_comment: 'هل أنت متأكد أنك تريد حذف تعليقك؟',
   user_not_found_error: 'خطأ: لم يتم العثور على المستخدم',
+  invalid_account_name: 'يرجى إدخال اسم مستخدم صالح للحساب.',
+  account_lookup_failed: 'تعذر التحقق من الحساب. يرجى المحاولة مرة أخرى.',
   need_login_signup_notice_vote: 'تحتاج إلى تسجيل الدخول أو التسجيل أولاً',
   Reply: 'الرد',
   Full_AFIT_Payout_Mode: 'وضع الدفع الكامل لـ AFIT',

--- a/lang/de_DE.js
+++ b/lang/de_DE.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'Sie haben bereits für diesen Beitrag gestimmt. Sind Sie sicher, dass Sie Ihre Stimme ändern möchten?',
   confirm_delete_comment: 'Sind Sie sicher, dass Sie Ihren Kommentar löschen möchten?',
   user_not_found_error: 'Fehler: Benutzer nicht gefunden',
+  invalid_account_name: 'Bitte geben Sie einen gültigen Kontonamen ein.',
+  account_lookup_failed: 'Das Konto konnte nicht überprüft werden. Bitte versuchen Sie es erneut.',
   need_login_signup_notice_vote: 'Sie müssen sich zuerst anmelden oder registrieren',
   Reply: 'Antworten',
   Full_AFIT_Payout_Mode: 'Vollständiger AFIT-Auszahlungsmodus',

--- a/lang/en_US.js
+++ b/lang/en_US.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'You already had voted before on this post. Are you sure you want to change your vote?',
   confirm_delete_comment: 'Are you sure you want to delete your comment?',
   user_not_found_error: 'Error: User Not Found',
+  invalid_account_name: 'Please enter a valid account username.',
+  account_lookup_failed: 'Unable to verify the account. Please try again.',
   need_login_signup_notice_vote: 'You need to login or signup first',
   Reply: 'Reply',
   Full_AFIT_Payout_Mode: 'Full AFIT Payout Mode',

--- a/lang/es_ES.js
+++ b/lang/es_ES.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'Ya has votado antes en esta publicación. ¿Estás seguro de que quieres cambiar tu voto?',
   confirm_delete_comment: '¿Estás seguro de que quieres eliminar tu comentario?',
   user_not_found_error: 'Error: Usuario No Encontrado',
+  invalid_account_name: 'Introduce un nombre de usuario de cuenta válido.',
+  account_lookup_failed: 'No se pudo verificar la cuenta. Inténtalo de nuevo.',
   need_login_signup_notice_vote: 'Necesitas iniciar sesión o registrarte primero',
   Reply: 'Responder',
   Full_AFIT_Payout_Mode: 'Modo de Pago Completo de AFIT',

--- a/lang/fr_FR.js
+++ b/lang/fr_FR.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'Vous aviez déjà voté sur cette publication. Êtes-vous sûr de vouloir changer votre vote ?',
   confirm_delete_comment: 'Êtes-vous sûr de vouloir supprimer votre commentaire ?',
   user_not_found_error: 'Erreur : Utilisateur non trouvé',
+  invalid_account_name: 'Veuillez saisir un nom de compte valide.',
+  account_lookup_failed: 'Impossible de vérifier le compte. Veuillez réessayer.',
   need_login_signup_notice_vote: 'Vous devez vous connecter ou vous inscrire d\'abord',
   Reply: 'Répondre',
   Full_AFIT_Payout_Mode: 'Mode de paiement intégral en AFIT',

--- a/lang/hi_IN.js
+++ b/lang/hi_IN.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'आपने इस पोस्ट पर पहले ही वोट कर दिया था। क्या आप वाकई अपना वोट बदलना चाहते हैं?',
   confirm_delete_comment: 'क्या आप वाकई अपनी टिप्पणी हटाना चाहते हैं?',
   user_not_found_error: 'त्रुटि: उपयोगकर्ता नहीं मिला',
+  invalid_account_name: 'कृपया एक मान्य खाता उपयोगकर्ता नाम दर्ज करें।',
+  account_lookup_failed: 'खाते की पुष्टि नहीं की जा सकी। कृपया पुनः प्रयास करें।',
   need_login_signup_notice_vote: 'आपको पहले लॉग इन या साइन अप करना होगा',
   Reply: 'जवाब',
   Full_AFIT_Payout_Mode: 'पूर्ण AFIT भुगतान मोड',

--- a/lang/it_IT.js
+++ b/lang/it_IT.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'Hai già votato questo post. Sei sicuro di voler cambiare il tuo voto?',
   confirm_delete_comment: 'Sei sicuro di voler eliminare il tuo commento?',
   user_not_found_error: 'Errore: Utente Non Trovato',
+  invalid_account_name: 'Inserisci un nome utente valido.',
+  account_lookup_failed: 'Impossibile verificare l\'account. Riprova.',
   need_login_signup_notice_vote: 'Devi prima accedere o iscriverti',
   Reply: 'Rispondi',
   Full_AFIT_Payout_Mode: 'Modalità Pagamento Completo AFIT',

--- a/lang/ja_JP.js
+++ b/lang/ja_JP.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'この投稿にはすでに投票しています。投票を変更してもよろしいですか？',
   confirm_delete_comment: 'コメントを削除してもよろしいですか？',
   user_not_found_error: 'エラー：ユーザーが見つかりません',
+  invalid_account_name: '有効なアカウント名を入力してください。',
+  account_lookup_failed: 'アカウントを確認できませんでした。もう一度お試しください。',
   need_login_signup_notice_vote: 'まずログインまたはサインアップする必要があります',
   Reply: '返信',
   Full_AFIT_Payout_Mode: '全AFIT支払いモード',

--- a/lang/pl_PL.js
+++ b/lang/pl_PL.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'Już wcześniej głosowałeś na ten post. Czy na pewno chcesz zmienić swój głos?',
   confirm_delete_comment: 'Czy na pewno chcesz usunąć swój komentarz?',
   user_not_found_error: 'Błąd: Nie znaleziono użytkownika',
+  invalid_account_name: 'Wprowadź prawidłową nazwę użytkownika konta.',
+  account_lookup_failed: 'Nie udało się zweryfikować konta. Spróbuj ponownie.',
   need_login_signup_notice_vote: 'Musisz się najpierw zalogować lub zarejestrować',
   Reply: 'Odpowiedz',
   Full_AFIT_Payout_Mode: 'Tryb pełnej wypłaty AFIT',

--- a/lang/pt_PT.js
+++ b/lang/pt_PT.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'Você já votou nesta postagem antes. Tem certeza que deseja alterar seu voto?',
   confirm_delete_comment: 'Tem certeza que deseja excluir seu comentário?',
   user_not_found_error: 'Erro: Usuário não Encontrado',
+  invalid_account_name: 'Introduza um nome de utilizador de conta válido.',
+  account_lookup_failed: 'Não foi possível verificar a conta. Tente novamente.',
   need_login_signup_notice_vote: 'Você precisa fazer login ou se inscrever primeiro',
   Reply: 'Responder',
   Full_AFIT_Payout_Mode: 'Modo de Pagamento Completo de AFIT',

--- a/lang/ru_RU.js
+++ b/lang/ru_RU.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'Вы уже голосовали за этот пост. Вы уверены, что хотите изменить свой голос?',
   confirm_delete_comment: 'Вы уверены, что хотите удалить свой комментарий?',
   user_not_found_error: 'Ошибка: пользователь не найден',
+  invalid_account_name: 'Введите корректное имя пользователя.',
+  account_lookup_failed: 'Не удалось проверить аккаунт. Попробуйте ещё раз.',
   need_login_signup_notice_vote: 'Вам нужно сначала войти или зарегистрироваться',
   Reply: 'Ответить',
   Full_AFIT_Payout_Mode: 'Режим полной выплаты в AFIT',

--- a/lang/tr_TR.js
+++ b/lang/tr_TR.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'Bu gönderiye daha önce oy vermiştiniz. Oyunuzu değiştirmek istediğinizden emin misiniz?',
   confirm_delete_comment: 'Yorumunuzu silmek istediğinizden emin misiniz?',
   user_not_found_error: 'Hata: Kullanıcı Bulunamadı',
+  invalid_account_name: 'Lütfen geçerli bir hesap kullanıcı adı girin.',
+  account_lookup_failed: 'Hesap doğrulanamadı. Lütfen tekrar deneyin.',
   need_login_signup_notice_vote: 'Önce giriş yapmanız veya kaydolmanız gerekir',
   Reply: 'Yanıtla',
   Full_AFIT_Payout_Mode: 'Tam AFIT Ödeme Modu',

--- a/lang/uk_UA.js
+++ b/lang/uk_UA.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: 'Ви вже голосували за цей допис. Ви впевнені, що хочете змінити свій голос?',
   confirm_delete_comment: 'Ви впевнені, що хочете видалити свій коментар?',
   user_not_found_error: 'Помилка: користувача не знайдено',
+  invalid_account_name: 'Введіть коректне ім\'я користувача.',
+  account_lookup_failed: 'Не вдалося перевірити обліковий запис. Спробуйте ще раз.',
   need_login_signup_notice_vote: 'Вам потрібно спочатку увійти або зареєструватися',
   Reply: 'Відповісти',
   Full_AFIT_Payout_Mode: 'Режим повної виплати в AFIT',

--- a/lang/zh_CN.js
+++ b/lang/zh_CN.js
@@ -395,6 +395,8 @@ module.exports = {
   confirm_vote_change: '您之前已经对这篇帖子投过票了。您确定要更改您的投票吗？',
   confirm_delete_comment: '您确定要删除您的评论吗？',
   user_not_found_error: '错误：用户未找到',
+  invalid_account_name: '请输入有效的账户用户名。',
+  account_lookup_failed: '无法验证账户，请重试。',
   need_login_signup_notice_vote: '您需要先登录或注册',
   Reply: '回复',
   Full_AFIT_Payout_Mode: '全AFIT支付模式',

--- a/pages/password.vue
+++ b/pages/password.vue
@@ -19,7 +19,7 @@
 			<p class="text-brand" v-if="!user && captcha_invalid">
 				  <b>{{ captcha_invalid }}</b>
 				</p>
-			<button v-on:click="fetchKeys" class="btn btn-brand btn-lg">{{ $t('Fetch_keys') }}<i class="fas fa-spin fa-spinner text-white" v-if="fetchingPass"></i></button>
+			<button v-on:click="fetchKeys" class="btn btn-brand btn-lg" :disabled="fetchingPass">{{ $t('Fetch_keys') }}<i class="fas fa-spin fa-spinner text-white" v-if="fetchingPass"></i></button>
 			<div class="text-brand" v-if="errorFetch">{{ errorFetch }}</div>
 			<div class="form-group">
 			  <div class="font-italic mb-2">{{ $t('Posting_key_desc') }}</div>
@@ -202,6 +202,8 @@
   import VueRecaptcha from 'vue-recaptcha';
   
   import QRious from 'qrious';
+
+  const ACCOUNT_LOOKUP_TIMEOUT_MS = 10000;
   
   export default {
 	head () {
@@ -427,6 +429,65 @@
 		this.assignQRCode(this.$refs['ownkey-qr'], privateKeys.owner);
 		this.assignQRCode(this.$refs['memokey-qr'], privateKeys.memo);
 	  },
+	  getAccountApiNode() {
+		const curBchain = localStorage.getItem('cur_bchain') || 'HIVE';
+		if (curBchain == 'STEEM') {
+		  return process.env.steemApiNode;
+		}
+		if (curBchain == 'BLURT') {
+		  return process.env.blurtApiNode;
+		}
+		return process.env.hiveApiNode;
+	  },
+	  cancelAccountLookup() {
+		if (this._accountLookupController) {
+		  this._accountLookupController.abort();
+		  this._accountLookupController = null;
+		}
+	  },
+	  async getAccountsWithTimeout(username) {
+		this.cancelAccountLookup();
+		const controller = new AbortController();
+		this._accountLookupController = controller;
+		let timedOut = false;
+		const timeoutId = setTimeout(() => {
+		  timedOut = true;
+		  controller.abort();
+		}, ACCOUNT_LOOKUP_TIMEOUT_MS);
+		try {
+		  const response = await fetch(this.getAccountApiNode(), {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+			  jsonrpc: '2.0',
+			  method: 'condenser_api.get_accounts',
+			  params: [[username]],
+			  id: 1
+			}),
+			signal: controller.signal
+		  });
+		  if (!response.ok) {
+			throw new Error(`Account lookup failed with status ${response.status}`);
+		  }
+		  const result = await response.json();
+		  if (result.error) {
+			throw new Error(result.error.message || 'Account lookup failed');
+		  }
+		  return Array.isArray(result.result) ? result.result : [];
+		} catch (error) {
+		  if (error.name === 'AbortError') {
+			const abortError = new Error(timedOut ? 'Account lookup timed out' : 'Account lookup cancelled');
+			abortError.code = timedOut ? 'ACCOUNT_LOOKUP_TIMEOUT' : 'ACCOUNT_LOOKUP_CANCELLED';
+			throw abortError;
+		  }
+		  throw error;
+		} finally {
+		  clearTimeout(timeoutId);
+		  if (this._accountLookupController === controller) {
+			this._accountLookupController = null;
+		  }
+		}
+	  },
 	  async fetchKeys () {
 		this.captcha_invalid = '';
 		if (!this.user && !this.captchaValid){
@@ -436,68 +497,79 @@
 		//ensure we have proper password to fetch keys
 		this.fetchingPass = true;
 		this.errorFetch = '';
-		let chainLnk = await this.setProperNode();
-		if (this.user){
-			let auths = {
-				posting: this.user.account.posting.key_auths,
-				active: this.user.account.active.key_auths,
-				owner: this.user.account.owner.key_auths,
+		this.resetKeys();
+
+		try {
+		  const chainLnk = this.setProperNode();
+		  const password = this.$refs['passfetchdata'].value;
+
+		  if (this.user){
+			const auths = {
+			  posting: this.user.account.posting.key_auths,
+			  active: this.user.account.active.key_auths,
+			  owner: this.user.account.owner.key_auths,
 			};
-			if (this.$refs["passfetchdata"].value == '' || ! await this.verifyPass(this.$refs["passfetchdata"].value, auths)){
+			if (password == '' || !await this.verifyPass(password, auths)){
 			  this.errorFetch = this.$t('Error_provide_password');
-			  this.fetchingPass = false;
-			  this.resetKeys();
 			  return;
 			}
-			
-			let privateKeys = await chainLnk.auth.getPrivateKeys(this.user.account.name, this.$refs["passfetchdata"].value);
-			//console.log(privateKeys);
+
+			const privateKeys = await chainLnk.auth.getPrivateKeys(this.user.account.name, password);
 			this.privatePostKey = privateKeys.posting;
 			this.privateActKey = privateKeys.active;
 			this.privateOwnKey = privateKeys.owner;
 			this.privateMemoKey = privateKeys.memo;
-			
-			//also generate proper QR codes
 			this.genQRCodes(privateKeys);
-		}else{
-			if (this.$refs["username"].value == ''){// || ! await this.verifyPass(this.$refs["passfetchdata"].value, auths)
-			  this.errorFetch = this.$t('Error_provide_password');
-			  this.fetchingPass = false;
-			  this.resetKeys();
-			  return;
-			}
-			//grab account info
-			let acctInfo = await chainLnk.api.getAccountsAsync([this.$refs["username"].value]);
-			//console.log(acctInfo[0]);
-			if (Array.isArray(acctInfo) && acctInfo.length > 0){
-				let auths = {
-					posting: acctInfo[0].posting.key_auths,
-					active: acctInfo[0].active.key_auths,
-					owner: acctInfo[0].owner.key_auths,
-				};
-				if (this.$refs["passfetchdata"].value == '' || ! await this.verifyUserPass(this.$refs["passfetchdata"].value, auths, this.$refs["username"].value)){
-				  this.errorFetch = this.$t('Error_provide_password');
-				  this.fetchingPass = false;
-				  this.resetKeys();
-				  return;
-				}
-				let privateKeys = await chainLnk.auth.getPrivateKeys(this.$refs['username'].value, this.$refs["passfetchdata"].value);
-				//console.log(privateKeys);
-				this.privatePostKey = privateKeys.posting;
-				this.privateActKey = privateKeys.active;
-				this.privateOwnKey = privateKeys.owner;
-				this.privateMemoKey = privateKeys.memo;
-				
-				//also generate proper QR codes
-				this.genQRCodes(privateKeys);
-			}else{
-				this.errorFetch = this.$t('Error_provide_password');
-				this.fetchingPass = false;
-				this.resetKeys();
-				return;
-			}
+			return;
+		  }
+
+		  const username = this.$refs['username'].value.trim().toLowerCase();
+		  if (!username){
+			this.errorFetch = this.$t('user_not_found_error');
+			return;
+		  }
+		  if (!password){
+			this.errorFetch = this.$t('Error_provide_password');
+			return;
+		  }
+
+		  const formatError = chainLnk.utils.validateAccountName(username);
+		  if (formatError !== null){
+			this.errorFetch = this.$t('invalid_account_name');
+			return;
+		  }
+
+		  const acctInfo = await this.getAccountsWithTimeout(username);
+		  if (!Array.isArray(acctInfo) || acctInfo.length === 0){
+			this.errorFetch = this.$t('user_not_found_error');
+			return;
+		  }
+
+		  const auths = {
+			posting: acctInfo[0].posting.key_auths,
+			active: acctInfo[0].active.key_auths,
+			owner: acctInfo[0].owner.key_auths,
+		  };
+		  if (!await this.verifyUserPass(password, auths, username)){
+			this.errorFetch = this.$t('Error_provide_password');
+			return;
+		  }
+
+		  const privateKeys = await chainLnk.auth.getPrivateKeys(username, password);
+		  this.privatePostKey = privateKeys.posting;
+		  this.privateActKey = privateKeys.active;
+		  this.privateOwnKey = privateKeys.owner;
+		  this.privateMemoKey = privateKeys.memo;
+		  this.genQRCodes(privateKeys);
+		} catch (error) {
+		  if (error.code === 'ACCOUNT_LOOKUP_CANCELLED') {
+			return;
+		  }
+		  console.error('Unable to fetch account keys:', error);
+		  this.errorFetch = this.$t('account_lookup_failed');
+		} finally {
+		  this.fetchingPass = false;
 		}
-		this.fetchingPass = false;
 		
 	  },
 	  setPasswordVal(){
@@ -757,6 +829,9 @@
 		blurt.api.setOptions({ url: process.env.blurtApiNode });
 		await this.setProperNode();
 		this.$store.dispatch('steemconnect/login')
+	},
+	beforeDestroy () {
+	  this.cancelAccountLookup();
 	}
   }
 </script>

--- a/test/unit/pages/password-account-lookup.spec.js
+++ b/test/unit/pages/password-account-lookup.spec.js
@@ -1,0 +1,183 @@
+import PasswordPage from '~/pages/password.vue'
+
+const originalFetch = global.fetch
+
+const makeContext = (overrides = {}) => ({
+  captchaValid: true,
+  captcha_invalid: '',
+  user: null,
+  fetchingPass: false,
+  errorFetch: '',
+  privatePostKey: '',
+  privateActKey: '',
+  privateOwnKey: '',
+  privateMemoKey: '',
+  $refs: {
+    username: { value: 'missing-user' },
+    passfetchdata: { value: 'password' }
+  },
+  $t: jest.fn(key => key),
+  resetKeys: jest.fn(),
+  genQRCodes: jest.fn(),
+  verifyUserPass: jest.fn(),
+  setProperNode: jest.fn(),
+  getAccountsWithTimeout: jest.fn(),
+  ...overrides
+})
+
+describe('password account lookup', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+    jest.useRealTimers()
+    global.fetch = originalFetch
+  })
+
+  it('rejects an invalid username before making a network request', async () => {
+    const chain = {
+      utils: { validateAccountName: jest.fn(() => 'Account name should be shorter.') }
+    }
+    const context = makeContext({
+      setProperNode: jest.fn(() => chain)
+    })
+
+    await PasswordPage.methods.fetchKeys.call(context)
+
+    expect(context.errorFetch).toBe('invalid_account_name')
+    expect(context.getAccountsWithTimeout).not.toHaveBeenCalled()
+    expect(context.fetchingPass).toBe(false)
+  })
+
+  it('shows user not found and stops loading when the account does not exist', async () => {
+    const chain = {
+      utils: { validateAccountName: jest.fn(() => null) }
+    }
+    const context = makeContext({
+      setProperNode: jest.fn(() => chain),
+      getAccountsWithTimeout: jest.fn(() => Promise.resolve([]))
+    })
+
+    await PasswordPage.methods.fetchKeys.call(context)
+
+    expect(context.errorFetch).toBe('user_not_found_error')
+    expect(context.getAccountsWithTimeout).toHaveBeenCalledWith('missing-user')
+    expect(context.fetchingPass).toBe(false)
+  })
+
+  it('stops loading when the account request fails', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const chain = {
+      utils: { validateAccountName: jest.fn(() => null) }
+    }
+    const context = makeContext({
+      setProperNode: jest.fn(() => chain),
+      getAccountsWithTimeout: jest.fn(() => Promise.reject(new Error('node unavailable')))
+    })
+
+    await PasswordPage.methods.fetchKeys.call(context)
+
+    expect(context.errorFetch).toBe('account_lookup_failed')
+    expect(context.fetchingPass).toBe(false)
+    expect(consoleError).toHaveBeenCalled()
+  })
+
+  it('still derives keys for an existing account with the correct password', async () => {
+    const account = {
+      posting: { key_auths: [['posting-key', 1]] },
+      active: { key_auths: [['active-key', 1]] },
+      owner: { key_auths: [['owner-key', 1]] }
+    }
+    const privateKeys = {
+      posting: 'private-posting',
+      active: 'private-active',
+      owner: 'private-owner',
+      memo: 'private-memo'
+    }
+    const chain = {
+      utils: { validateAccountName: jest.fn(() => null) },
+      auth: { getPrivateKeys: jest.fn(() => privateKeys) }
+    }
+    const context = makeContext({
+      $refs: {
+        username: { value: ' Alice ' },
+        passfetchdata: { value: 'correct-password' }
+      },
+      setProperNode: jest.fn(() => chain),
+      getAccountsWithTimeout: jest.fn(() => Promise.resolve([account])),
+      verifyUserPass: jest.fn(() => true)
+    })
+
+    await PasswordPage.methods.fetchKeys.call(context)
+
+    expect(context.getAccountsWithTimeout).toHaveBeenCalledWith('alice')
+    expect(context.verifyUserPass).toHaveBeenCalledWith('correct-password', {
+      posting: account.posting.key_auths,
+      active: account.active.key_auths,
+      owner: account.owner.key_auths
+    }, 'alice')
+    expect(chain.auth.getPrivateKeys).toHaveBeenCalledWith('alice', 'correct-password')
+    expect(context.privatePostKey).toBe(privateKeys.posting)
+    expect(context.privateActKey).toBe(privateKeys.active)
+    expect(context.privateOwnKey).toBe(privateKeys.owner)
+    expect(context.privateMemoKey).toBe(privateKeys.memo)
+    expect(context.genQRCodes).toHaveBeenCalledWith(privateKeys)
+    expect(context.errorFetch).toBe('')
+    expect(context.fetchingPass).toBe(false)
+  })
+
+  it('times out an account request after ten seconds', async () => {
+    jest.useFakeTimers()
+    let requestSignal
+    global.fetch = jest.fn((url, options) => {
+      requestSignal = options.signal
+      return new Promise((resolve, reject) => {
+        options.signal.addEventListener('abort', () => {
+          const error = new Error('aborted')
+          error.name = 'AbortError'
+          reject(error)
+        })
+      })
+    })
+    const context = {
+      _accountLookupController: null,
+      cancelAccountLookup: PasswordPage.methods.cancelAccountLookup,
+      getAccountApiNode: jest.fn(() => 'https://api.hive.blog')
+    }
+
+    const lookup = PasswordPage.methods.getAccountsWithTimeout.call(context, 'missing-user')
+    const assertion = expect(lookup).rejects.toMatchObject({
+      message: 'Account lookup timed out',
+      code: 'ACCOUNT_LOOKUP_TIMEOUT'
+    })
+    jest.advanceTimersByTime(10000)
+
+    await assertion
+    expect(requestSignal.aborted).toBe(true)
+    expect(context._accountLookupController).toBe(null)
+  })
+
+  it('uses the selected node for an abortable JSON-RPC account lookup', async () => {
+    const account = { name: 'alice' }
+    global.fetch = jest.fn(() => Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ result: [account] })
+    }))
+    const context = {
+      _accountLookupController: null,
+      cancelAccountLookup: PasswordPage.methods.cancelAccountLookup,
+      getAccountApiNode: jest.fn(() => 'https://api.hive.blog')
+    }
+
+    const result = await PasswordPage.methods.getAccountsWithTimeout.call(context, 'alice')
+
+    expect(result).toEqual([account])
+    expect(global.fetch).toHaveBeenCalledWith('https://api.hive.blog', expect.objectContaining({
+      method: 'POST',
+      signal: expect.any(AbortSignal)
+    }))
+    const request = JSON.parse(global.fetch.mock.calls[0][1].body)
+    expect(request).toMatchObject({
+      method: 'condenser_api.get_accounts',
+      params: [['alice']]
+    })
+  })
+})


### PR DESCRIPTION
Restores Reem's account-recovery fix from #362 (the original PR's source branch was removed, so this re-lands the identical commit `295b0ab` onto develop). Prevents the password page from loading indefinitely on an invalid username: resets the loading flag in a `finally`, adds a 10s abortable account lookup with timeout, immediate username validation, localized errors across all 14 locales, and regression tests.

Authored by @reemnii. Reviewed — clean, merge-ready.

Co-authored-by: Reem Nemr <rnimer9@gmail.com>