### PR TITLE
fix(images): serve usermedia.actifit.io images directly (Hive proxy 403s that host)

### DIFF
--- a/components/UserSidebar.vue
+++ b/components/UserSidebar.vue
@@ -166,14 +166,20 @@ export default {
             ? JSON.parse(post.json_metadata) 
             : post.json_metadata;
         if (meta && meta.image && Array.isArray(meta.image) && meta.image.length > 0 && meta.image[0]) {
-          return `https://images.hive.blog/400x225/${meta.image[0]}`;
+          return this.hiveResized(meta.image[0], '400x225');
         }
       } catch (e) { }
       if (post.body) {
         const match = post.body.match(/https?:\/\/[^)\s]+\.(?:png|jpg|jpeg|gif|webp)/i);
-        if (match) return `https://images.hive.blog/400x225/${match[0]}`;
+        if (match) return this.hiveResized(match[0], '400x225');
       }
       return null;
+    },
+    hiveResized(url, size) {
+      // usermedia.actifit.io / already-hive-hosted images aren't served by the
+      // Hive resize proxy (403) — use them directly.
+      if (url.startsWith('https://images.hive.blog') || url.startsWith('https://usermedia.actifit.io')) return url;
+      return `https://images.hive.blog/${size}/${url}`;
     },
     getPostCardBackground(post) {
         const imageUrl = this.getPostImage(post);

--- a/plugins/commonCardMixin.js
+++ b/plugins/commonCardMixin.js
@@ -183,7 +183,9 @@ export const commonCardMixin = {
     },
 
     getResizedImageUrl (url, width) {
-      if (typeof url !== 'string' || !url.startsWith('http') || /\.gif$/i.test(url) || url.includes('leopedia.io')) {
+      // usermedia.actifit.io (Actifit's own upload host) is not served by the
+      // Hive image proxy (returns 403), so — like gif/leopedia — use it directly.
+      if (typeof url !== 'string' || !url.startsWith('http') || /\.gif$/i.test(url) || url.includes('leopedia.io') || url.includes('usermedia.actifit.io')) {
         return url;
       }
       const resizeProxy = `https://images.hive.blog/${Math.round(width)}x0/`;

--- a/plugins/vue-custom.js
+++ b/plugins/vue-custom.js
@@ -416,7 +416,9 @@ Vue.prototype.$cleanBody = function (report_content, full_cleanup, no_media){
 		if (!url || typeof url !== 'string') return '';
 		url = url.trim();
 		if (!url.startsWith('http')) return '';
-		const proxiedUrl = (url.startsWith('https://images.hive.blog') || url.toLowerCase().endsWith('.gif'))
+		// usermedia.actifit.io (Actifit's own upload host) is not served by the
+		// Hive image proxy (403), so serve it directly like already-hive-hosted / gif images.
+		const proxiedUrl = (url.startsWith('https://images.hive.blog') || url.startsWith('https://usermedia.actifit.io') || url.toLowerCase().endsWith('.gif'))
 			? url
 			: `https://images.hive.blog/0x0/${url}`;
 		return `<img src="${escapeHtmlAttr(proxiedUrl)}">`;
@@ -672,13 +674,19 @@ Vue.prototype.$uuidv4 = function(){
 
 Vue.prototype.$fetchHiveFmtPostImage = function (metaData){
 	if (this.$postHasImage(metaData)){
+		let imgUrl;
 		try{
 			//find first occurrence that is url
-			return 'https://images.hive.blog/0x0/' + metaData.image.find(element => /^(http|https):\/\//.test(element));
+			imgUrl = metaData.image.find(element => /^(http|https):\/\//.test(element));
 		}catch(err){
 			//alt image case
-			return 'https://images.hive.blog/0x0/' + metaData.images.find(element => /^(http|https):\/\//.test(element));
+			imgUrl = metaData.images.find(element => /^(http|https):\/\//.test(element));
 		}
+		if (!imgUrl) return "";
+		// usermedia.actifit.io / already-hive-hosted images are not served by the
+		// Hive image proxy (403) — return them directly instead of a broken proxy URL.
+		if (imgUrl.startsWith('https://images.hive.blog') || imgUrl.startsWith('https://usermedia.actifit.io')) return imgUrl;
+		return 'https://images.hive.blog/0x0/' + imgUrl;
 	}
 	return "";
 };

--- a/test/unit/plugins/commonCardMixin.spec.js
+++ b/test/unit/plugins/commonCardMixin.spec.js
@@ -1,0 +1,33 @@
+// commonCardMixin imports steem + hive-js at module load; stub them so importing
+// the mixin has no side effects. We only exercise the pure getResizedImageUrl logic.
+jest.mock('steem', () => ({}))
+jest.mock('@hiveio/hive-js', () => ({}))
+
+import { commonCardMixin } from '@/plugins/commonCardMixin'
+
+const { getResizedImageUrl } = commonCardMixin.methods
+
+describe('commonCardMixin.getResizedImageUrl', () => {
+  it('proxies a normal external image through the Hive resizer', () => {
+    expect(getResizedImageUrl('https://example.com/pic.png', 350))
+      .toBe('https://images.hive.blog/350x0/https://example.com/pic.png')
+  })
+
+  // Regression: Actifit's own upload host (usermedia.actifit.io) is NOT served by
+  // the Hive image proxy — it returns 403 — so those images must be used directly,
+  // otherwise post/card previews for Actifit-hosted images render broken.
+  it('serves usermedia.actifit.io images directly (Hive proxy 403s that host)', () => {
+    const url = 'https://usermedia.actifit.io/MS4O55L7RQDBFPXM1TB9OSX81DK1JR'
+    expect(getResizedImageUrl(url, 350)).toBe(url)
+  })
+
+  it('leaves gif and leopedia.io images untouched (pre-existing bypasses)', () => {
+    expect(getResizedImageUrl('https://x.com/a.gif', 350)).toBe('https://x.com/a.gif')
+    expect(getResizedImageUrl('https://leopedia.io/img.png', 350)).toBe('https://leopedia.io/img.png')
+  })
+
+  it('returns non-http / non-string input unchanged', () => {
+    expect(getResizedImageUrl('/local/relative.png', 350)).toBe('/local/relative.png')
+    expect(getResizedImageUrl(null, 350)).toBe(null)
+  })
+})


### PR DESCRIPTION
## Problem

Post/card **previews for Actifit-hosted images render broken** (blank thumbnail). Example: `https://actifit.io/hdev/blog` — the HivePulse SEO-contest post shows no preview while other posts do.

## Root cause (verified)

The post's cover is on **`usermedia.actifit.io`** (Actifit's own upload host). The image helpers route every image through **Hive's resizer** (`images.hive.blog/<size>/<url>`), but Hive's proxy **returns 403 for `usermedia.actifit.io`** — it only serves already-hive-hosted / allow-listed sources.

Reproduced:
- Direct source `usermedia.actifit.io/…` → **200 OK** (image is fine).
- `images.hive.blog/350x0/https://usermedia.actifit.io/…` → **403 Forbidden**.
- `images.hive.blog/350x0/https://images.hive.blog/DQm…` (native) → **200 OK**.

The helper `getResizedImageUrl` already bypasses the proxy for `.gif` and `leopedia.io` (same 403 class). `usermedia.actifit.io` — ironically Actifit's own host — just needs the same treatment.

## Fix

Add `usermedia.actifit.io` to the proxy-bypass in the four image-URL builders so those images are served **directly** (confirmed 200 OK):
- `plugins/commonCardMixin.js` → `getResizedImageUrl` (card thumbnails — the reported case)
- `plugins/vue-custom.js` → `createProxiedImageTag` (`$cleanBody` body images)
- `plugins/vue-custom.js` → `$fetchHiveFmtPostImage` (metadata image getter)
- `components/UserSidebar.vue` → `getPostImage` (sidebar previews)

Plus a unit test for `getResizedImageUrl` covering the usermedia bypass, the normal-proxy path, and the existing gif/leopedia bypasses.

## Trade-off / follow-up

Bypassed images skip Hive's resizing and load at **source resolution** (e.g. a 1.5 MB cover into a 350 px card — bandwidth cost). The **ideal long-term fix is a resize endpoint on `usermedia.actifit.io`** (or uploading post images to `images.hive.blog`); this PR makes previews **work now** and matches the existing bypass pattern.

## Verification
- `commonCardMixin.spec.js` (new) and `vue-custom.spec.js` (existing) — all green (33 tests).
- Production build compiles clean.
