### PR TITLE
Release 1.12.0 (re-deploy): package-lock.json sync fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4936,6 +4936,32 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/@nuxt/cli/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/@nuxt/cli/node_modules/crc": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/crc/-/crc-4.3.2.tgz",
@@ -22326,6 +22352,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -27610,6 +27647,17 @@
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
         "crc": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/crc/-/crc-4.3.2.tgz",
@@ -40160,6 +40208,13 @@
         "has-symbols": "^1.1.0",
         "which-boxed-primitive": "^1.1.1"
       }
+    },
+    "undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "optional": true,
+      "peer": true
     },
     "undici-types": {
       "version": "7.19.2",


### PR DESCRIPTION
Re-ships 1.12.0 with the lockfile fix (#368). The previous develop->master merge (#367) had a package-lock.json out of sync with package.json (missing direct dep `undici`), so DigitalOcean's `npm ci` failed and 1.12.0 never deployed. This brings the corrected lockfile to master to re-trigger a passing build/deploy. Only change vs current master: package-lock.json (+55 lines, undici subtree).