### PR TITLE
docs: trim infra/security specifics from public README & CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,8 @@ Layered strategy — see `test/README.md` for full details.
 - Jest mock factories must prefix referenced vars with `mock` (Jest hoisting rule).
 - Many store actions never call `resolve()` but `commit` asynchronously — tests
   fire the action and flush the microtask queue rather than awaiting it.
-- **Prod/deploy:** set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` in the DigitalOcean app
-  env so `npm ci` does not download browser binaries on every deploy.
+- **Prod/deploy:** set `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` in the deploy
+  environment so `npm ci` does not download browser binaries on every deploy.
 
 ## Node.js Version
 
@@ -52,13 +52,7 @@ Node.js **v16** is required (pinned in `.nvmrc` as v16.20.2). The project uses `
 
 ## Security Architecture (Critical)
 
-**Never put secrets in the `env` block of `nuxt.config.js`** — that block leaks into the client bundle. Secrets belong in `privateRuntimeConfig` (reads from `process.env` at runtime, server-side only).
-
-Client-side code that needs secrets must call the server-side proxy at `api/proxy.js`:
-- `/api/proxy/gemini` — Google Gemini AI
-- `/api/proxy/deepl` — DeepL translation
-- `/api/proxy/reward-comment`, `/api/proxy/reward-vote`, `/api/proxy/reward-edit` — reward system
-- `/api/proxy/upload` — image upload to `usermedia.actifit.io`
+**Never put secrets in the `env` block of `nuxt.config.js`** — that block leaks into the client bundle. Secrets belong in `privateRuntimeConfig` (reads from `process.env` at runtime, server-side only). Client-side code that needs a secret must route through the server-side proxy in `api/proxy.js` instead of embedding the key — never expose keys client-side.
 
 ## i18n Coupling
 
@@ -70,7 +64,7 @@ Language files live in `lang/` (14 locales, default `en_US.js`). `config/index.j
 
 ## Deployment
 
-No CI pipeline. Production is hosted on **DigitalOcean App Platform** (served behind Cloudflare — live responses carry `x-do-app-origin` headers), which **auto-deploys on push to `master`**. The build runs **`npm ci`** under **Node 16.20.2 / npm 8.19.4**, so `package.json` and `package-lock.json` must stay perfectly in sync or the build fails at install with `EUSAGE`. DigitalOcean uses Heroku-compatible buildpacks, so the `heroku-postbuild` script (`npm run build`) is likely still the build step the buildpack invokes — do not assume it is dead and remove it. `.env` is gitignored; required env vars are configured in the DigitalOcean app and consumed via `privateRuntimeConfig` and `env` blocks in `nuxt.config.js`.
+Production auto-builds from `master` via **`npm ci`**, so `package.json` and `package-lock.json` must stay perfectly in sync or the build fails at install with `EUSAGE` (see the README "Releasing" section for the pre-flight check). The `heroku-postbuild` script (`npm run build`) is the build step — do not assume it is dead and remove it. `.env` is gitignored; runtime secrets are provided via the host env and read through `privateRuntimeConfig`.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -21,33 +21,24 @@ $ yarn run generate
 
 > **Note:** this project uses **npm / `package-lock.json`** — the `yarn` commands above are historical; use the `npm` equivalents (`npm install`, `npm run dev`, `npm run build`, `npm start`, `npm run generate`).
 
-## Deployment & Releasing
+## Releasing
 
-Production (**actifit.io**) runs on **DigitalOcean App Platform** and **auto-deploys on every push to `master`**. The build runs **`npm ci`** (Node 16.20.2 / npm 8.19.4), which installs strictly from `package-lock.json` and **fails hard** if `package.json` and the lockfile are out of sync.
+The production build runs **`npm ci`**, which installs strictly from `package-lock.json` and **fails if it is out of sync with `package.json`**.
 
-### ⚠️ Pre-flight before merging `develop → master`
+### ⚠️ Pre-flight before a release
 
-Always run a **clean `npm ci`** locally first — **not** just `npm install`:
+Always run a clean **`npm ci`** locally first — **not** just `npm install`:
 
 ``` bash
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
+npm ci
 ```
 
-`npm install` (especially under a newer npm major, e.g. npm 10 on Node 20) **silently tolerates** a lockfile that's out of sync with `package.json` — for example, a direct dependency listed in `package.json` that has no top-level entry in the lock. But DigitalOcean's `npm ci` **fails with `EUSAGE` (`Missing: <pkg> from lock file`)**, so the build never ships and **the live site silently stays on the previous version**. (This blocked the 1.12.0 release: `undici` was a direct dep missing from the lock.)
+`npm install` silently tolerates a lockfile that is out of sync with `package.json` (e.g. a direct dependency with no top-level entry in the lock), but `npm ci` **fails with `EUSAGE` (`Missing: <pkg> from lock file`)** — which blocks the production build even though local dev looks fine. Matching the `version` fields is not enough; only `npm ci` catches a dependency-tree desync.
 
-Matching the `version` fields is **not** enough — only `npm ci` catches a dependency-tree desync.
-
-### Fixing a lockfile desync
+Fix a desync by regenerating the lockfile, then commit **only** `package-lock.json` and re-run `npm ci` to confirm:
 
 ``` bash
-# regenerate the lock (keep lockfileVersion 2 — the format DO's npm 8 uses)
 npm install --package-lock-only --lockfile-version 2
-# commit ONLY package-lock.json, then re-verify:
-PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm ci
 ```
-
-### After merging to `master`
-
-The deploy takes ~5–15 min. If the live build hasn't changed after ~15 min, check **DigitalOcean → Apps → actifit-landingpage → Deployments** — a failed `npm ci` (EUSAGE) is the most common cause.
 
 For detailed explanation on how things work, checkout [Nuxt.js docs](https://nuxtjs.org).


### PR DESCRIPTION
The repo is public. Removes backend/infra roadmap detail (hosting provider, exact toolchain versions, the enumerated secret proxy endpoints) from README and CLAUDE.md while keeping the useful guidance (npm ci pre-flight, secrets-via-proxy principle). Docs-only.

Note: this removes it from the current files going forward; the prior content remains in git history (a full scrub would need a history rewrite — separate decision).