### PR TITLE
Release 1.12.1 — hotfix: restore posting-key login (reCAPTCHA eager load)

### DIFF
--- a/components/LoginModal.vue
+++ b/components/LoginModal.vue
@@ -67,10 +67,7 @@
   // YOUR CURRENT, IMPROVED SCRIPT IS PRESERVED
   import { VueReCaptcha } from 'vue-recaptcha-v3'
   import Vue from 'vue'
-  // reCAPTCHA is installed lazily (see ensureRecaptcha) when the login modal is
-  // opened — NOT at import time. This component is imported by the always-present
-  // navbar, so a module-level Vue.use() loaded the Google reCAPTCHA script on
-  // every page (including the homepage) and blocked the main thread on load.
+  Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key })
   import QRious from 'qrious';
   import { PublicKey, Signature, hash } from '@hiveio/hive-js/lib/auth/ecc';
 
@@ -120,14 +117,13 @@
       $(this.$refs.loginModal).on('show.bs.modal', () => {
         this.originalTitle = document.title;
         document.title = this.$t('Login_actifit');
-        // Load reCAPTCHA only once the user actually opens the login modal.
-        this.ensureRecaptcha();
       });
       $(this.$refs.loginModal).on('hidden.bs.modal', () => {
         document.title = this.originalTitle;
         this.resetForm();
         this.$emit('close');
       });
+      await this.$recaptchaLoaded();
       this.verifyKeychain();
     },
     beforeDestroy() {
@@ -151,14 +147,14 @@
         let acct_data = json.HIVE; let userSC = new Object(); userSC.account = acct_data; this.is_logged_in = true; this.$store.commit('setStdLoginUser', true); localStorage.setItem('acti_login_method', 'hiveauth'); localStorage.setItem('access_token', this.hiveauth_token); localStorage.setItem('expires', this.hiveauth_expire); localStorage.setItem('key', this.hiveauth_key); localStorage.setItem('std_login', true); localStorage.setItem('std_login_name', userSC.account.name); this.$store.commit('steemconnect/login', userSC); this.closeModal(); this.resetForm(); this.$store.dispatch('steemconnect/refreshUser'); this.$store.dispatch('fetchModerators');
       },
       setKeychainLoginStatus (json){
-        if (json && json.success && json.token && json.userdata){ const recaptcha = this.$recaptchaInstance; if (recaptcha) recaptcha.hideBadge(); let acct_data = json.userdata; let userSC = new Object(); userSC.account = acct_data; this.is_logged_in = true; this.$store.commit('setStdLoginUser', true); localStorage.setItem('access_token', json.token); localStorage.setItem('std_login', true); localStorage.setItem('std_login_name', userSC.account.name); localStorage.setItem('acti_login_method', 'keychain'); this.$store.commit('steemconnect/login', userSC); this.closeModal(); this.resetForm(); this.$store.dispatch('steemconnect/refreshUser'); this.$store.dispatch('fetchModerators'); }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); return; }
+        if (json && json.success && json.token && json.userdata){ const recaptcha = this.$recaptchaInstance; recaptcha.hideBadge(); let acct_data = json.userdata; let userSC = new Object(); userSC.account = acct_data; this.is_logged_in = true; this.$store.commit('setStdLoginUser', true); localStorage.setItem('access_token', json.token); localStorage.setItem('std_login', true); localStorage.setItem('std_login_name', userSC.account.name); localStorage.setItem('acti_login_method', 'keychain'); this.$store.commit('steemconnect/login', userSC); this.closeModal(); this.resetForm(); this.$store.dispatch('steemconnect/refreshUser'); this.$store.dispatch('fetchModerators'); }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); return; }
       },
       setUserLoginStatus (json, postingKey) {
-        this.is_logged_in = json.success; if (json.success && json.token){ const recaptcha = this.$recaptchaInstance; if (recaptcha) recaptcha.hideBadge(); localStorage.setItem('actiToken', json.token); let userSC = new Object(); userSC.account = json.userdata; this.$store.commit('setStdLoginUser', true); this.$store.commit('setChatPostingKey', postingKey); localStorage.setItem('access_token', json.token); localStorage.setItem('std_login', true); localStorage.setItem('std_login_name', userSC.account.name); localStorage.setItem('acti_login_method', ''); this.$store.commit('steemconnect/login', userSC); this.closeModal(); this.resetForm(); this.$store.dispatch('steemconnect/refreshUser'); this.$store.dispatch('fetchModerators'); this.$emit('login-successful'); }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); }
+        this.is_logged_in = json.success; if (json.success && json.token){ const recaptcha = this.$recaptchaInstance; recaptcha.hideBadge(); localStorage.setItem('actiToken', json.token); let userSC = new Object(); userSC.account = json.userdata; this.$store.commit('setStdLoginUser', true); this.$store.commit('setChatPostingKey', postingKey); localStorage.setItem('access_token', json.token); localStorage.setItem('std_login', true); localStorage.setItem('std_login_name', userSC.account.name); localStorage.setItem('acti_login_method', ''); this.$store.commit('steemconnect/login', userSC); this.closeModal(); this.resetForm(); this.$store.dispatch('steemconnect/refreshUser'); this.$store.dispatch('fetchModerators'); this.$emit('login-successful'); }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); }
       },
       verifyHiveauth (challenge, data){ const sig = Signature.fromHex(data.challenge); const buf = hash.sha256(challenge, null, 0); return sig.verifyHash(buf, PublicKey.fromString(data.pubkey)); },
 async loginHiveauth (){
-        if (this.$refs["username"].value == ''){ this.error_proceeding = true; this.error_msg = this.$t('login_error'); return; } this.login_in_progress = true; let account = this.$refs["username"].value.trim().toLowerCase(); const APP_META = { name:"actifit", description: process.env.socialSharingTitle, icon:"https://actifit.io/img/actifit_logo.png" }; const auth = { username: account, expire: undefined, key: undefined, }; const status = this.$HAS.status(); let challenge_data = { key_type: "posting", challenge: JSON.stringify({ login: account, ts: Date.now(), }) }; let mainRef = this; this.$HAS.authenticate(auth, APP_META, challenge_data, (message) => { if (message.cmd && message.cmd === 'auth_wait'){ this.hiveauth_wait = true; this.$nextTick(() => { const authPayload = { uuid: message.uuid, account: account, key: message.key, host: 'wss://hive-auth.arcange.eu' }; this.hiveauth_key = message.key; const authUri = `has://auth_req/${btoa(JSON.stringify(authPayload))}`; const qrLinkElement = mainRef.$refs['hiveauth-qr-link']; const qrElement = mainRef.$refs['hiveauth-qr']; const QR = new QRious({ element: qrElement, background: 'white', backgroundAlpha: 0.8, foreground: 'black', size: 200, }); QR.value = authUri; qrLinkElement.href = authUri; }); } }).then(async (message) => { if (message.cmd && message.cmd === 'auth_ack'){ const { data } = message; const { expire, token } = data; const success = this.verifyHiveauth(challenge_data.challenge, data.challenge); this.hiveauth_wait = false; this.hiveauth_expire = expire; this.hiveauth_token = token; if (success){ const recaptcha = this.$recaptchaInstance; if (recaptcha) recaptcha.hideBadge(); this.login_in_progress = false; try { const acctController = new AbortController(); const acctTimeoutId = setTimeout(() => acctController.abort(), 20000); const acctRes = await fetch('/api/proxy/getAccountData?user='+encodeURIComponent(account)+'&bchain=HIVE', { signal: acctController.signal }); clearTimeout(acctTimeoutId); const acctJson = await acctRes.json(); this.setHiveauthLoginStatus(acctJson); } catch (e) { console.error('HiveAuth account data error:', e); this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); } }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); return; } }else if (message.cmd && message.cmd === 'auth_nack'){ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('auth_rejected_by_user'); return; } }).catch(err => { console.error(err); this.error_proceeding = true; this.error_msg = this.$t('login_error'); this.hiveauth_wait = false; this.login_in_progress = false; });
+        if (this.$refs["username"].value == ''){ this.error_proceeding = true; this.error_msg = this.$t('login_error'); return; } this.login_in_progress = true; let account = this.$refs["username"].value.trim().toLowerCase(); const APP_META = { name:"actifit", description: process.env.socialSharingTitle, icon:"https://actifit.io/img/actifit_logo.png" }; const auth = { username: account, expire: undefined, key: undefined, }; const status = this.$HAS.status(); let challenge_data = { key_type: "posting", challenge: JSON.stringify({ login: account, ts: Date.now(), }) }; let mainRef = this; this.$HAS.authenticate(auth, APP_META, challenge_data, (message) => { if (message.cmd && message.cmd === 'auth_wait'){ this.hiveauth_wait = true; this.$nextTick(() => { const authPayload = { uuid: message.uuid, account: account, key: message.key, host: 'wss://hive-auth.arcange.eu' }; this.hiveauth_key = message.key; const authUri = `has://auth_req/${btoa(JSON.stringify(authPayload))}`; const qrLinkElement = mainRef.$refs['hiveauth-qr-link']; const qrElement = mainRef.$refs['hiveauth-qr']; const QR = new QRious({ element: qrElement, background: 'white', backgroundAlpha: 0.8, foreground: 'black', size: 200, }); QR.value = authUri; qrLinkElement.href = authUri; }); } }).then(async (message) => { if (message.cmd && message.cmd === 'auth_ack'){ const { data } = message; const { expire, token } = data; const success = this.verifyHiveauth(challenge_data.challenge, data.challenge); this.hiveauth_wait = false; this.hiveauth_expire = expire; this.hiveauth_token = token; if (success){ const recaptcha = this.$recaptchaInstance; recaptcha.hideBadge(); this.login_in_progress = false; try { const acctController = new AbortController(); const acctTimeoutId = setTimeout(() => acctController.abort(), 20000); const acctRes = await fetch('/api/proxy/getAccountData?user='+encodeURIComponent(account)+'&bchain=HIVE', { signal: acctController.signal }); clearTimeout(acctTimeoutId); const acctJson = await acctRes.json(); this.setHiveauthLoginStatus(acctJson); } catch (e) { console.error('HiveAuth account data error:', e); this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); } }else{ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('login_error'); return; } }else if (message.cmd && message.cmd === 'auth_nack'){ this.error_proceeding = true; this.login_in_progress = false; this.error_msg = this.$t('auth_rejected_by_user'); return; } }).catch(err => { console.error(err); this.error_proceeding = true; this.error_msg = this.$t('login_error'); this.hiveauth_wait = false; this.login_in_progress = false; });
       },
       async verifyKeychain () {
         return new Promise((resolve) => { if (window.hive_keychain) { this.keychain = window.hive_keychain; this.keychain.requestHandshake(() => { this.keychain_available = true; resolve(); }); } })
@@ -222,18 +218,11 @@ async loginHiveauth (){
           this.error_msg = this.$t('login_error');
         }
       },
-      // Installs vue-recaptcha-v3 (and loads the Google script) on first use.
-      // Vue.use is idempotent, so calling this repeatedly is safe.
-      ensureRecaptcha () {
-        Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key });
-        return this.$recaptchaLoaded();
-      },
       async proceedLogin () {
         this.captcha_invalid = '';
         this.error_proceeding = false;
         this.error_msg = '';
         if (this.$refs["username"].value == '' || this.$refs["ppkey"].value == ''){ this.error_proceeding = true; this.error_msg = this.$t('login_error'); return; }
-        await this.ensureRecaptcha();
         const token = await this.$recaptcha('login');
         let outc = await fetch('/api/proxy/verifyLoginCaptcha?token='+encodeURIComponent(token));
         let captchaJson = await outc.json();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actifit-landingpage",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "hasInstallScript": true,
       "dependencies": {
         "@blurtfoundation/blurtjs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "Actifit is an innovative dapp that aims to incentivize fitness and healthy lifestyle via rewarding daily activity.",
   "author": "mktcode",
   "private": true,

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -89,9 +89,7 @@
   //import {keychain, isKeychainInstalled, hasKeychainBeenUsed} from '@hiveio/keychain'
 
   import Vue from 'vue'
-  // reCAPTCHA is installed lazily in mounted() so this page's module has no
-  // import-time side effect (a module-level Vue.use loaded reCAPTCHA on other
-  // pages, e.g. the homepage, blocking the main thread).
+  Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key })
 
   //QR display for hive auth
   import QRious from 'qrious';
@@ -175,8 +173,9 @@
 		} catch (e) {
 		  console.log(e);
 		}*/
-		Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key })
+		console.log('load recaptcha')
 		await this.$recaptchaLoaded()
+		console.log('complete')
 		this.verifyKeychain();
 	},
 	methods: {

--- a/pages/signup.vue
+++ b/pages/signup.vue
@@ -374,8 +374,7 @@ import { VueReCaptcha } from 'vue-recaptcha-v3'
 import { mapGetters } from 'vuex'
 import Vue from 'vue'
 
-// reCAPTCHA is installed lazily in mounted() so this module has no import-time
-// side effect (a module-level Vue.use loaded reCAPTCHA on other pages too).
+Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key })
 
 export default {
   head() {
@@ -517,7 +516,6 @@ export default {
     this.$store.dispatch('fetchUserRank')
     this.$store.dispatch('fetchReferrals')
 
-    Vue.use(VueReCaptcha, { siteKey: process.env.captchaV3Key })
     await this.$recaptchaLoaded()
 
   },


### PR DESCRIPTION
## Release 1.12.1 — production login hotfix

Promotes `develop` → `master`. Live goes **1.12.0 → 1.12.1**.

### Fix
- **Posting-key login broken on production** (`verifyLoginCaptcha` → `{error:"error"}`). Root cause: the 1.12.0 perf PR (#358) deferred `Vue.use(VueReCaptcha)` from module-load to modal-open/page-mount; the token generated after the deferred install fails Google verification. Reverted to the known-working eager (module-level) install in `LoginModal.vue`, `login.vue`, `signup.vue`. All other #358 perf wins are untouched. (#374)

### Notes
- Auto-deploys to production (DigitalOcean) on merge to `master`.
- `npm ci` pre-flight passed (lockfile in sync).
- Post-deploy: smoke-test posting-key login (plus Keychain / HiveAuth) once the `_nuxt/<hash>.js` chunk set changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)