### PR TITLE
The post screen is hiding activity count and activity type

### DIFF
--- a/components/ReportModal.vue
+++ b/components/ReportModal.vue
@@ -829,6 +829,13 @@ export default {
   text-align: center;
 }
 
+html:not(.dark-mode) #reportModal .modal-body img[src*="ACTIVITYCOUNT"] + .text-center,
+html:not(.dark-mode) #reportModal .modal-body img[src*="ACTIVITYCOUNT"] + .text-center *,
+html:not(.dark-mode) #reportModal .modal-body img[src*="ACTIVITYTYPE"] + .text-center,
+html:not(.dark-mode) #reportModal .modal-body img[src*="ACTIVITYTYPE"] + .text-center * {
+  color: #000 !important;
+}
+
 .modal-author {
   margin-left: 10px !important;
 }

--- a/components/ReportModal.vue
+++ b/components/ReportModal.vue
@@ -805,7 +805,7 @@ export default {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff !important;
+  color: var(--text-color) !important;
   text-align: center;
 }
 
@@ -816,7 +816,7 @@ export default {
 #reportModal .modal-body img[src*="ACTIVITYDATE"] + .text-center *,
 #reportModal .modal-body img[src*="ACTIVITYCOUNT"] + .text-center *,
 #reportModal .modal-body img[src*="ACTIVITYTYPE"] + .text-center * {
-  color: #fff !important;
+  color: var(--text-color) !important;
 }
 
 #reportModal .modal-body img[src*="ACTIVITYTYPE"] + .text-center pre {
@@ -825,7 +825,7 @@ export default {
   padding: 0;
   border: 0;
   background: transparent;
-  color: #fff !important;
+  color: var(--text-color) !important;
   text-align: center;
 }
 


### PR DESCRIPTION
<img width="1920" height="1080" alt="Screenshot (739)" src="https://github.com/user-attachments/assets/5ab392f3-1d39-4a9b-8074-0649ca65719b" />
<img width="1920" height="1080" alt="Screenshot (740)" src="https://github.com/user-attachments/assets/d956709d-034f-4269-b10a-d683316d9741" />
<img width="1920" height="1080" alt="Screenshot (742)" src="https://github.com/user-attachments/assets/331c7d53-ccb2-4d73-b41c-a22c88986567" />
<img width="1920" height="1080" alt="Screenshot (741)" src="https://github.com/user-attachments/assets/b5f71a5b-b05d-4bf6-9e6b-58a6fd039c66" />
Updates report activity labels to use the shared --text-color theme variable, ensuring correct light/dark mode colors without extra overrides.