### PR TITLE
chore: bump version to 1.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actifit-landingpage",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "hasInstallScript": true,
       "dependencies": {
         "@blurtfoundation/blurtjs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Actifit is an innovative dapp that aims to incentivize fitness and healthy lifestyle via rewarding daily activity.",
   "author": "mktcode",
   "private": true,


### PR DESCRIPTION
Release version bump for the develop → master deploy shipping the privacy-policy Data Retention / Data Deletion sections (#383, Play Store compliance) plus accumulated develop maintenance commits.

Bumps `package.json` + `package-lock.json` 1.12.1 → 1.12.2 (in sync, so the `npm ci` deploy won't fail).