### PR TITLE
fix(deps): sync package-lock.json to unblock 1.12.2 production deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4948,6 +4948,32 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/@nuxt/cli/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/@nuxt/cli/node_modules/crc": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/crc/-/crc-4.3.2.tgz",
@@ -22311,6 +22337,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
@@ -27595,6 +27632,17 @@
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
         "crc": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/crc/-/crc-4.3.2.tgz",
@@ -38617,7 +38665,7 @@
       "requires": {
         "@parcel/watcher": "^2.4.1",
         "chokidar": "^5.0.0",
-        "immutable": "^5.1.5",
+        "immutable": "^5.1.9",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "dependencies": {
@@ -40127,6 +40175,13 @@
         "has-symbols": "^1.1.0",
         "which-boxed-primitive": "^1.1.1"
       }
+    },
+    "undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "optional": true,
+      "peer": true
     },
     "undici-types": {
       "version": "7.19.2",


### PR DESCRIPTION
## Problem
The **1.12.2 release (#390)** merged to master **without the `npm ci` pre-flight**, and the lockfile was out of sync with `package.json`. DigitalOcean's build failed at install:

\`\`\`
npm error code EUSAGE
Missing: undici@6.28.0 from lock file
Missing: buffer@6.0.3 from lock file
\`\`\`

So the deploy failed and **production is stuck on the previous build**.

## Fix
Regenerated the lockfile with `npm install --package-lock-only --lockfile-version 2` (keeps lockfileVersion 2 for DO's npm 8). Adds the two missing transitive entries — **lockfile-only, +56/−1, no source/version change**. `npm ci` now passes the sync gate (verified locally via `npm ci` and `--dry-run`; the EUSAGE/Missing error is gone).

Needs to reach **master** to re-trigger the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)