### PR TITLE
ci: add lockfile-sync guard (npm ci) to prevent silent deploy failures

### DIFF
--- a/.github/workflows/lockfile-sync.yml
+++ b/.github/workflows/lockfile-sync.yml
@@ -1,0 +1,32 @@
+name: Lockfile sync
+
+# Guards against the silent production-deploy failure where package-lock.json is
+# out of sync with package.json: DigitalOcean builds via `npm ci`, which hard-fails
+# with EUSAGE ("Missing: <pkg> from lock file") and the deploy never ships (live
+# silently stays on the old build). This has happened twice (1.12.0, 1.12.2) when a
+# release skipped the local pre-flight. This job reproduces the DO install so a
+# desync shows a red X on the PR before merge, regardless of who cuts the release.
+
+on:
+  pull_request:
+    branches: [develop, master]
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+jobs:
+  npm-ci:
+    name: npm ci (package-lock.json in sync)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc' # v16.20.2, matching the DigitalOcean build
+      - name: npm ci (mirrors the DigitalOcean production build)
+        # Any package.json <-> package-lock.json desync fails here with EUSAGE,
+        # exactly as the deploy would — catching it before it reaches master.
+        run: npm ci
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'


### PR DESCRIPTION
## Why
The production deploy has silently failed **twice** (1.12.0, 1.12.2) because a release merged `develop→master` with `package-lock.json` out of sync with `package.json`. DigitalOcean builds via `npm ci`, which hard-fails with `EUSAGE ("Missing: <pkg> from lock file")`, so the deploy never ships and live stays on the old build. Docs/memory can't enforce the pre-flight across sessions.

## What
A small GitHub Actions workflow (`.github/workflows/lockfile-sync.yml`) that runs **`npm ci` on Node 16.20.2 (via `.nvmrc`, mirroring DO)** for any PR into `develop`/`master` that touches `package.json` or `package-lock.json`. A desync now shows a **red ✗ on the PR before merge**.

- Check-only, no app/source change.
- Gates PRs into `develop` (where desyncs originate) immediately; reaches `master` with the next release to also gate release PRs.

## To make it a hard block
Set **"Lockfile sync / npm ci (package-lock.json in sync)"** as a **required status check** in branch protection for `develop` and `master` (needs repo admin — can't be done from the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)