### PR TITLE
ci: run lockfile-sync on all PRs (fix required-check deadlock)

### DIFF
--- a/.github/workflows/lockfile-sync.yml
+++ b/.github/workflows/lockfile-sync.yml
@@ -6,13 +6,15 @@ name: Lockfile sync
 # silently stays on the old build). This has happened twice (1.12.0, 1.12.2) when a
 # release skipped the local pre-flight. This job reproduces the DO install so a
 # desync shows a red X on the PR before merge, regardless of who cuts the release.
+#
+# NOTE: no `paths:` filter — this check is *required* in branch protection, and a
+# required check that gets path-skipped stays "pending" forever and blocks every
+# PR that doesn't touch package files (GitHub gotcha). Running on all PRs to
+# develop/master guarantees it always reports a status. npm ci is ~2-3 min.
 
 on:
   pull_request:
     branches: [develop, master]
-    paths:
-      - 'package.json'
-      - 'package-lock.json'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The `npm ci` check we made **required** in branch protection has a `paths:` filter. A required check that gets path-skipped stays *pending* forever and **blocks any PR that doesn't touch package files** — which is currently blocking #364 (`Required status check "npm ci (package-lock.json in sync)" is expected`).

Fix: remove the `paths` filter so the job always runs and always reports a status. Cost: ~2-3 min npm ci on every PR to develop/master (acceptable; correctness > a few CI minutes).

⚠️ Landing this PR (and #364) requires a **one-time** relaxation of develop branch protection — see the note I'll leave, since this PR also doesn't touch package files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)