### PR TITLE
fix(i18n): preserve locale when redirecting category post URLs

### DIFF
--- a/pages/_tag/_username/_permlink/index.vue
+++ b/pages/_tag/_username/_permlink/index.vue
@@ -29,7 +29,8 @@ export default {
   },
   created () {
 	if ((typeof this.$route.params !== 'undefined') && (typeof this.$route.params.tag !== 'undefined') &&(typeof this.$route.params.username !== 'undefined') && (typeof this.$route.params.permlink !== 'undefined') ) {
-	  this.$router.push({ path: "/"+this.$route.params.username+"/"+this.$route.params.permlink })
+	  // localePath keeps the active locale prefix (e.g. /de) — a raw path drops it and forces English
+	  this.$router.push(this.localePath("/"+this.$route.params.username+"/"+this.$route.params.permlink))
 	}else{
 		this.errorDisplay = this.$t('error_post_not_found');
 	}


### PR DESCRIPTION
## Bug
Opening any single post while browsing in a non-English language silently kicks you back to **English**.

Post links across the app use Hive's category-style URL — `/hive-xxx/@author/permlink` — which routes to `pages/_tag/_username/_permlink/index.vue`. That page's only job is to redirect to the canonical `/@author/permlink`. It did so with a **raw `/`-path**:

```js
this.$router.push({ path: "/"+params.username+"/"+params.permlink })
```

Under `@nuxtjs/i18n`'s default `prefix_except_default` strategy, a raw path **omits the active locale prefix**, so:
- `/de/hive-xxx/@a/p` → `/@a/p`  (drops `/de`, locale flips to `en`)

## Fix
Wrap the target in `localePath()`, which keeps the current locale prefix:
```js
this.$router.push(this.localePath("/"+params.username+"/"+params.permlink))
```

## Verified (dev, all via the category URL)
| Locale | Before | After |
|---|---|---|
| en | `/@a/p` | `/@a/p` ✅ |
| de | `/@a/p` ❌ | `/de/@a/p` ✅ |
| fr | `/@a/p` ❌ | `/fr/@a/p` ✅ |
| ar | `/@a/p` ❌ | `/ar/@a/p` ✅ |

Each lands on the post, renders it, and keeps the correct `$i18n.locale`.

- One-line change; lint clean; full suite 306 pass / 3 fail = develop baseline (pre-existing StingChat + email-obfuscation), no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)