### PR TITLE
fix(i18n): make navbar New Blog/New Video links locale-aware

### DIFF
--- a/components/NavbarBrand.vue
+++ b/components/NavbarBrand.vue
@@ -27,18 +27,18 @@
             </a>
           </li>
 
-          <li class="nav-item btn btn-brand m-1 nav-item-border" :title="$t('New_Blog')">
+          <li class="nav-item btn btn-brand m-1 nav-item-border" :title="$t('New_Blog')" v-if="user">
             <a class="nav-link text-white d-flex align-items-center justify-content-center w-100 h-100"
-               href="/blog/new"
-               @click.prevent="$router.push('/blog/new'); closeMenu()">
+               :href="localePath('/@' + user.account.name + '/blog/new')"
+               @click.prevent="$router.push(localePath('/@' + user.account.name + '/blog/new')); closeMenu()">
               <i class="fas fa-pen-to-square text-white"></i><span>{{ $t('New_Blog') }}</span>
             </a>
           </li>
 
-          <li class="nav-item btn btn-brand m-1 nav-item-border" :title="$t('Create_new_vid')">
+          <li class="nav-item btn btn-brand m-1 nav-item-border" :title="$t('Create_new_vid')" v-if="user">
             <a class="nav-link text-white d-flex align-items-center justify-content-center w-100 h-100"
-               href="/videos/new"
-               @click.prevent="$router.push('/videos/new'); closeMenu()">
+               :href="localePath('/@' + user.account.name + '/videos/new')"
+               @click.prevent="$router.push(localePath('/@' + user.account.name + '/videos/new')); closeMenu()">
               <i class="fas fa-video text-white"></i><span>{{ $t('Create_new_vid') }}</span>
             </a>
           </li>
@@ -103,8 +103,12 @@ href="#news"
 // ... (your script remains the same) ...
 import UserMenu from '~/components/UserMenu';
 import LoginModal from '~/components/LoginModal';
+import { mapGetters } from 'vuex';
 
 export default {
+  computed: {
+    ...mapGetters('steemconnect', ['user']),
+  },
   data() {
     return {
       isModalOpen: false,

--- a/components/UserMenu.vue
+++ b/components/UserMenu.vue
@@ -157,7 +157,7 @@
                 class="fas fa-running text-brand"></i> {{ $t('My_Activity') }}</NuxtLink>
             <NuxtLink class="dropdown-item" :to="localePath('/' + user.account.name + '/blog')"><i
                 class="fa-solid fa-pen-to-square text-brand"></i> {{ $t('My_Blog') }}</NuxtLink>
-            <NuxtLink class="dropdown-item" :to="localePath('/blog/new')"><i
+            <NuxtLink class="dropdown-item" :to="localePath('/' + user.account.name + '/blog/new')"><i
                 class="fa-solid fa-plus-square text-brand"></i> {{ $t('New_Blog') }}</NuxtLink>
             <NuxtLink class="dropdown-item" :to="localePath('/' + user.account.name + '/videos')"><i
                 class="fa-solid fa-video text-brand"></i> {{ $t('My_Videos') }}</NuxtLink>


### PR DESCRIPTION
## Bug
Clicking **New Blog** / **New Video** in the navbar while browsing in any non-English language lands on **"Could not load post."** instead of the editor.

The items pushed a bare, username-less path:
```js
$router.push('/blog/new')   // and '/videos/new'
```
That resolves to the editor **only in the default (en) locale**, via an `@nuxtjs/i18n` quirk (a literal `/_username/blog/new` route with empty params). Under a locale prefix there's no username-less editor route, so `/ar/blog/new` matches `/:username/:permlink` → `username="blog", permlink="new"` → the post loader → error. (Router-verified.)

## Fix
Point the links at the **canonical editor route with the logged-in username**, wrapped in `localePath` so the locale prefix is kept:
```js
$router.push(this.localePath('/@' + user.account.name + '/blog/new'))
```
`/ar/@you/blog/new` renders the editor in every locale (verified). Guarded with `v-if="user"` — posting needs an account, and it avoids a null-user deref. Adds the `steemconnect` `user` getter to `NavbarBrand`.

## Notes
- Pre-existing bug from the #356 navbar items; **independent of #399/#400**.
- Lint clean; compiles; `localePath('/@actifit/blog/new')` → `/ar/@actifit/blog/new` (works) confirmed via the router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)