### PR TITLE
test(seo): assert on crawler-visible nav links, not the composer links

### DIFF
--- a/test/unit/seo/internal-navigation.spec.js
+++ b/test/unit/seo/internal-navigation.spec.js
@@ -6,9 +6,13 @@ describe('internal navigation', () => {
   const conductPage = fs.readFileSync('pages/conduct.vue', 'utf8')
   const homePage = fs.readFileSync('pages/index.vue', 'utf8')
 
+  // Only assert on links a crawler can actually reach. The composer links
+  // (/blog/new, /videos/new) sit behind v-if="user" and are locale-aware via
+  // localePath(), so they are neither statically greppable nor visible to a
+  // logged-out crawler -- asserting on them tested nothing.
   it.each([
-    '/blog/new',
-    '/videos/new'
+    '/activity',
+    '/market'
   ])('links to %s from the primary navigation', route => {
     expect(primaryNavigation).toContain(`href="${route}"`)
   })


### PR DESCRIPTION
## Why develop is red

#401 made the New Blog / New Video navbar links locale-aware:

```
:href="localePath('/@' + user.account.name + '/blog/new')"
```

`internal-navigation.spec.js` greps `NavbarBrand.vue` as **source text** for the literal `href="/blog/new"`, so both cases have failed since that merged. The baseline on develop went from 3 known failures to 5, which means "jest is green" stopped being a usable signal for everyone working in this repo.

## Why repoint rather than update the expected string

Those two links were never a valid subject for this spec. Both `<li>` elements are `v-if="user"`, so a logged-out crawler never sees them — and since the spec reads source text rather than rendered output, it never verified crawler visibility in the first place. It passed for months while checking nothing.

`/activity` (`:24`) and `/market` (`:48`) are static and ungated, so they are what an SEO internal-navigation check should actually assert on. The other three cases in the file test real things and are untouched.

## Verification

- `npx jest test/unit/seo/internal-navigation.spec.js` → **5/5 pass**
- Mutation check: renaming `href="/activity"` in `NavbarBrand.vue` turns that case **red**, so the assertion is load-bearing rather than vacuously true
- Full suite → **3 failed / 306 passed**, back to the known baseline (`StingChat` ×2, `disable-email-obfuscation` ×1), down from 5

One file, test-only, no production code touched.