### PR TITLE
fix(post): #410 review follow-ups (test, dark-mode icons, logged-out reply)

### DIFF
--- a/pages/_username/_permlink/index.vue
+++ b/pages/_username/_permlink/index.vue
@@ -48,7 +48,7 @@
                       :user="user"
                       :voteCount="getVoteCount"
                       :hasVoted="userVotedThisPost()"
-                      :showReply="true"
+                      :showReply="!!user"
                       @reply="toggleCommentBox"
                       @vote-prompt="votePrompt($event)"
                       @open-modal="headToComments"
@@ -78,7 +78,7 @@
                     :user="user"
                     :voteCount="getVoteCount"
                     :hasVoted="userVotedThisPost()"
-                    :showReply="true"
+                    :showReply="!!user"
                     @reply="toggleCommentBox"
                     @vote-prompt="votePrompt($event)"
                     @open-modal="headToComments"
@@ -629,6 +629,7 @@ export default {
     },
 
     async postResponse(event) {
+      if (!this.user || !this.user.account) return; // reply needs a logged-in user; button is hidden when logged out, but guard defensively
       this.loading = true
       const comment_perm = this.user.account.name.replace('.', '-') + '-re-' + this.report.author.replace('.', '-') + '-' + this.report.permlink + new Date().toISOString().replace(/[^a-zA-Z0-9]+/g, '').toLowerCase();
       const meta = {
@@ -861,6 +862,18 @@ a:hover, a:hover, .text-brand:hover, .actifit-link-plain:hover { text-decoration
 .date-head { padding-left: 2px; }
 .report-comments .date-head { color: #6c757d !important; }
 .report-reply { padding-left: 40px; padding-bottom: 40px; }
+
+/* Header action strip reuses CardActions, which reads --post-footer-* vars; define them here
+   too (they're otherwise scoped to the footer) so the header icons aren't the illegible #333
+   fallback — matters in dark mode. */
+.header-post-actions {
+  --post-footer-brand: #FF112D;
+  --post-footer-brand-dark: #D40E24;
+  --post-footer-border: #E6E8EB;
+  --post-footer-muted: #6B7280;
+  --post-footer-muted-soft: #9AA0A6;
+  --post-footer-green: #1E8E5A;
+}
 
 #main-footer.post-detail-footer {
   --post-footer-brand: #FF112D;

--- a/test/unit/pages/_username/_permlink/index.spec.js
+++ b/test/unit/pages/_username/_permlink/index.spec.js
@@ -185,10 +185,11 @@ describe('permlink page vote wiring and legacy-strip selector', () => {
     wrapper.destroy()
   })
 
-  it('hides the old top action strip with a real selector, not a ref selector', () => {
+  it('renders the action strip in the post header (not the removed legacy strip)', () => {
     const source = fs.readFileSync('pages/_username/_permlink/index.vue', 'utf8')
 
-    expect(source).toContain('.report-head .legacy-post-actions')
-    expect(source).not.toContain('#reportTarget .legacy-post-actions')
+    // The old hidden legacy strip was replaced by a CardActions in the header (top + bottom).
+    expect(source).toContain('header-post-actions')
+    expect(source).not.toContain('legacy-post-actions')
   })
 })


### PR DESCRIPTION
Post-merge review of #410 flagged three items; this addresses all three.

1. **🔴 Failing unit test** — a spec asserted the exact CSS rule #410 removed (`.report-head .legacy-post-actions`). Updated it to assert the new state (header renders `CardActions`, no `legacy-post-actions`). Spec now 3/3 green.
2. **🟠 Dark-mode legibility** — the header `CardActions` read `--post-footer-*` vars scoped only to the footer, so its icons fell back to `#333` (illegible on the dark `#212121` bg). Defined those vars on `.header-post-actions` — header icons now render at the proper muted `#6B7280` in both themes.
3. **🟡 Logged-out reply** — `showReply` was hard `true`, so the reply button showed logged-out and clicking Post hit `postResponse` → null-`user` crash. Gated `:showReply="!!user"` (header **and** footer) and guarded `postResponse()` defensively (the #404 footer already exposed this path).

## Verified
- `jest` (affected spec): **3/3 pass**. Full suite: no new failures (2 pre-existing unrelated suites — StingChat, disable-email-obfuscation — fail on develop too).
- eslint clean.
- Live (logged-out): header + footer show only **Votes / Comments** (Reply hidden); header icon color `rgb(107,114,128)`; 0 pageerrors.