### PR TITLE
fix(post): header action strip brand-red to match live/master (footer unchanged)

### DIFF
--- a/pages/_username/_permlink/index.vue
+++ b/pages/_username/_permlink/index.vue
@@ -864,14 +864,15 @@ a:hover, a:hover, .text-brand:hover, .actifit-link-plain:hover { text-decoration
 .report-reply { padding-left: 40px; padding-bottom: 40px; }
 
 /* Header action strip reuses CardActions, which reads --post-footer-* vars; define them here
-   too (they're otherwise scoped to the footer) so the header icons aren't the illegible #333
-   fallback — matters in dark mode. */
+   (they're otherwise scoped to the footer). The header sits on the brand-colored report head,
+   so — unlike the muted footer strip — its icons are brand red to match the live/master look
+   (also legible in dark mode). The footer strip is intentionally left as its muted styling. */
 .header-post-actions {
   --post-footer-brand: #FF112D;
   --post-footer-brand-dark: #D40E24;
   --post-footer-border: #E6E8EB;
-  --post-footer-muted: #6B7280;
-  --post-footer-muted-soft: #9AA0A6;
+  --post-footer-muted: #FF112D;
+  --post-footer-muted-soft: #FF112D;
   --post-footer-green: #1E8E5A;
 }
 


### PR DESCRIPTION
The header action strip restored in #410 inherited the footer's **muted-gray** CardActions color, so it looked different from **production (master)**, where the header actions are brand **red** (`text-brand`).

**Fix:** point the header's `--post-footer-muted` (scoped to `.header-post-actions`) at the brand red `#FF112D`, so the top strip matches the live look and stays legible in dark mode.

**The footer strip is intentionally untouched** — it keeps its muted styling (it looks good as-is).

## Verified (headless, real post)
- Header action color: `rgb(255,17,45)` (brand red) ✅ — matches the live screenshot
- Footer action color: `rgb(107,114,128)` (muted, unchanged) ✅
- eslint clean.