### PR TITLE
fix(post): header action icons white by default, red only when voted

### DIFF
--- a/pages/_username/_permlink/index.vue
+++ b/pages/_username/_permlink/index.vue
@@ -865,14 +865,15 @@ a:hover, a:hover, .text-brand:hover, .actifit-link-plain:hover { text-decoration
 
 /* Header action strip reuses CardActions, which reads --post-footer-* vars; define them here
    (they're otherwise scoped to the footer). The header sits on the brand-colored report head,
-   so — unlike the muted footer strip — its icons are brand red to match the live/master look
-   (also legible in dark mode). The footer strip is intentionally left as its muted styling. */
+   so its icons are WHITE by default (like master); the vote turns brand-red only when the
+   logged-in user has voted, via CardActions' --active state (--post-footer-brand). The footer
+   strip keeps its own muted styling and is intentionally left untouched. */
 .header-post-actions {
   --post-footer-brand: #FF112D;
   --post-footer-brand-dark: #D40E24;
   --post-footer-border: #E6E8EB;
-  --post-footer-muted: #FF112D;
-  --post-footer-muted-soft: #FF112D;
+  --post-footer-muted: #FFFFFF;
+  --post-footer-muted-soft: #FFFFFF;
   --post-footer-green: #1E8E5A;
 }
 


### PR DESCRIPTION
Corrects #412 (which made the whole header strip brand-red by default). The report head is brand-colored, so the action icons should be **white** by default (like master), and the **vote** turns **brand-red only when the logged-in user has voted** — same behavior as the footer vote button, via CardActions' `hasVoted` → `--active` state.

**Fix:** set the header's `--post-footer-muted` to white (the `--post-footer-brand` red stays for the active/voted state). Footer strip untouched.

## Verified (headless, real post + a real voter injected as the logged-in user)
- Logged-out: Reply/Votes/Comments/Reblog all **white**.
- Voter injected: **Votes = rgb(255,17,45) red** (active), Reply/Comments/Reblog stay white.
- Footer action color unchanged: rgb(107,114,128).