### PR TITLE
chore: disable the DHF proposal vote popup for now

### DIFF
--- a/components/VoteProposalModal.vue
+++ b/components/VoteProposalModal.vue
@@ -100,7 +100,9 @@ export default {
       }
     },
     adjustVisibility(){
-      this.visible = !this.userVotedProposal();
+      // Popup disabled for now — re-enable for Actifit's next DHF proposal by restoring:
+      //   this.visible = !this.userVotedProposal();
+      this.visible = false;
     }
   },
   async mounted() {


### PR DESCRIPTION
Disables the `VoteProposalModal` popup (the floating 'Support … Vote for their proposal' card) so it no longer shows to users, until Actifit's next DHF proposal.

**How:** `adjustVisibility()` now forces `visible = false` instead of `!userVotedProposal()`, so the modal's `v-if="visible && …"` never renders it. Reversible in one line (documented inline) — the rest of the component is untouched.

## Verified
- Homepage: `#voteProposalModal` is not in the DOM and not visible.
- eslint clean.