### PR TITLE
fix(cards): upvote shows red when the logged-in user has voted (card view)

### DIFF
--- a/components/CardActions.vue
+++ b/components/CardActions.vue
@@ -112,3 +112,15 @@ export default {
   }
 }
 </style>
+
+<style>
+/* Non-scoped fallback for the action colors. The scoped rules above match via CardActions'
+   data-v attribute, but on some render paths (notably the blog-listing cards) that attribute
+   is dropped from the <a class="post-detail-action"> element, so its scoped color rule never
+   applies and the vote icon stays black even when the user has voted. Re-declare the colors by
+   class (unscoped) so they land regardless. Values still resolve from the --post-footer-* vars
+   (or their fallbacks), so the header/footer strips keep their own colors. */
+.card-actions .post-detail-action { color: var(--post-footer-muted, #6b7280) !important; }
+.card-actions .post-detail-action:hover,
+.card-actions .post-detail-action--active { color: var(--post-footer-brand, #ff112d) !important; }
+</style>


### PR DESCRIPTION
## Regression
In the card/listing view, the upvote icon stayed **black** for posts the logged-in user had already upvoted (should be red). `postUpvoted` was actually computing correctly — the styling just never landed.

## Root cause (two compounding issues)
1. On the blog-listing render path, CardActions' **scoped `data-v` attribute is dropped** from the `<a class="post-detail-action">` (the child `<i>` keeps it), so CardActions' *scoped* color rules never match the `<a>`.
2. The global `assets/css/normal.css` rule `.report a, .post a { color: var(--text-color)!important }` (**black, !important**) then wins. The old action strip escaped this via `.text-brand` (there's a `.post a.text-brand` red rule), but the new `.post-detail-action--active` isn't covered.

## Fix
Add an **unscoped, class-based** color rule under `.card-actions` (specificity `0,2,0` > `.post a` `0,1,1`, with `!important`) so the action colors apply regardless of the missing scope attr. Values still resolve from the `--post-footer-*` vars, so the header/footer strips keep their own colors.

## Verified (headless, real voter injected)
- Card: **voted → red `rgb(255,17,45)`**, unvoted → muted `rgb(107,114,128)`.
- Single-post: header still **white** default, footer still **muted** — unaffected.