### PR TITLE
fix(cards): align activity & blog card views + polish (Trello #161)

### DIFF
--- a/components/CardHeader.vue
+++ b/components/CardHeader.vue
@@ -46,6 +46,7 @@ export default {
   background: #ff112d;
   padding: 8px 10px;
   min-height: 60px;
+  font-weight: 600; /* dial back the heavy <h6>/accent bold; consistent across blog + activity cards */
 }
 .card-title a {
   color: #fff;
@@ -61,7 +62,7 @@ export default {
   align-items: center;
   justify-content: center;
   background: #ff112d !important;
-  font-weight: 700;
+  font-weight: 600;
 }
 .card-title-accent a {
   display: block;

--- a/components/Post.vue
+++ b/components/Post.vue
@@ -2,7 +2,7 @@
   <!-- single post item for activity pages -->
   <div>
     <div :class="[isOnlyPost ? 'card post single' : { 'card-pinned': isPostPinned, 'card post': isStandardPost }, { 'is-comment': post.parent_author }]">
-      <CardHeader :title="post.title" :link="buildLink">
+      <CardHeader :title="post.title" :link="buildLink" :showExternalLink="false">
         <span v-if="isPostPinned" :title="$t('pinned_post')"> <i class="fas fa-thumbtack text-warning"></i></span>
       </CardHeader>
 

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -168,7 +168,10 @@ export default {
       return date.getDate() + '/' + (date.getMonth() + 1) + '/' + date.getFullYear() + ' ' + date.getHours() + ':' + (minutes < 10 ? '0' + minutes : minutes)
     },
     steps () {
-      return this.meta.step_count ? this.meta.step_count[0] : ''
+      const raw = this.meta.step_count ? this.meta.step_count[0] : ''
+      const n = Number(raw)
+      // thousand separator for the activity count, e.g. 6495 -> 6,495
+      return (raw !== '' && !isNaN(n)) ? n.toLocaleString('en-US') : raw
     },
     type () {
       return this.meta.activity_type ? this.meta.activity_type.join(', ') : ''


### PR DESCRIPTION
Actions Trello **[#161](https://trello.com/c/tOHjF2fG)** — polish the activity card and align blog/report card surfaces. Much of the structural alignment was already done by **#404** (shared `CardHeader`/`CardActions`/`CardBody`); this finishes the remaining polish.

## Changes
- **Title weight** — dialed the heavy `<h6>`/accent bold back to `font-weight: 600` on the shared `.card-title`, so **blog and activity titles match** and read less heavy (was 700 / `<h6>` default).
- **Activity count separator** — `Report.vue` now formats the count with thousands separators (e.g. `6495` → `6,495`).
- **Blog title link icon** — dropped the external-link icon (`:showExternalLink="false"`) so the blog title matches the activity card.

## Already aligned (verified, no change needed)
- **X / share icon** — measured at **16px, same as the chart/book siblings** (no oversizing or special hover); the old discrepancy was resolved when #404 moved sharing into the shared `CardActions` extra-actions slot.
- **Date shade** — both cards already use `text-muted`.

## Verified
Screenshotted the blog card (`/hdev/blog`) and activity card (`/activity/manuvert`) — titles now match weight, count shows `6,495`, blog title has no link icon, action rows uniform. eslint clean.