### PR TITLE
fix(cards): align X icon, read-more behavior & post links (blog vs activity)

### DIFF
--- a/components/CardBody.vue
+++ b/components/CardBody.vue
@@ -45,11 +45,10 @@
       <div class="col-12">
         <div v-if="expandableSnippet" class="report-snippet-section">
           <a
-            href="#"
+            :href="readMoreUrl"
+            target="_blank"
+            rel="noopener noreferrer"
             class="report-snippet-link"
-            @click.prevent="$emit('open-modal')"
-            :data-toggle="modalTarget ? 'modal' : null"
-            :data-target="modalTarget"
             :title="$t('read_more_small')"
           >
             <div
@@ -58,23 +57,20 @@
               v-html="snippet">
             </div>
           </a>
-          <button
+          <a
             v-if="hasSnippetOverflow"
-            type="button"
-            class="report-snippet-toggle"
-            :data-toggle="modalTarget ? 'modal' : null"
-            :data-target="modalTarget"
-            @click="$emit('open-modal')">
+            :href="readMoreUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="report-snippet-toggle">
             {{ $t('read_more') }}
-          </button>
+          </a>
         </div>
         <a
           v-else
-          href="#"
-          class=""
-          @click.prevent="$emit('open-modal')"
-          :data-toggle="modalTarget ? 'modal' : null"
-          :data-target="modalTarget"
+          :href="readMoreUrl"
+          target="_blank"
+          rel="noopener noreferrer"
           :title="$t('read_more_small')"
         >
           <div>
@@ -100,7 +96,8 @@ export default {
     imageGeneration: { type: Number, default: 0 },
     currentImageSrc: { type: String, default: '' },
     allImages: { type: Array, default: () => [] },
-    currentImageIndex: { type: Number, default: 0 }
+    currentImageIndex: { type: Number, default: 0 },
+    readMoreUrl: { type: String, default: '' }
   },
   emits: ['open-modal', 'image-load', 'image-error', 'next-image', 'prev-image', 'go-to-image'],
   data() {

--- a/components/Post.vue
+++ b/components/Post.vue
@@ -33,6 +33,7 @@
           :cardData="post"
           modalTarget="#postModal"
           :snippet="bodySnippet"
+          :readMoreUrl="buildLink"
           :imageLoadFailed="imageLoadFailed"
           :imageLoading="imageLoading"
           :imageGeneration="imageGeneration"
@@ -67,7 +68,7 @@
               </span>
             </social-sharing>
             <a href="#" class="text-brand" @click="$store.commit('setEditPost', post)" data-toggle="modal" data-target="#editPostModal" v-if="user && post.author === user.account.name" :title="$t('Edit_note')"><i class="fas fa-edit"></i></a>
-            <a href="#" class="text-brand" @click="post.pstId = pstId; $store.commit('setActivePost', post)" data-toggle="modal" data-target="#postModal" :title="$t('read_more_small')"><i class="fas fa-book-open"></i></a>
+            <a :href="buildLink" target="_blank" rel="noopener noreferrer" class="text-brand" :title="$t('read_more_small')"><i class="fas fa-book-open"></i></a>
           </template>
         </CardActions>
 
@@ -126,7 +127,7 @@ export default {
     cardData () { return this.post },
     // END: ADDED COMPUTED PROPERTY
     isOnlyPost () { return this.userPosts && this.userPosts.length === 1 },
-    buildLink () { return '/' + this.post.author + '/' + this.post.permlink },
+    buildLink () { return this.post.url || ('/' + this.post.author + '/' + this.post.permlink) },
     isPostReblog () { return this.displayUsername && this.displayUsername !== this.post.author },
     isPostPinned () { return this.post.stats ? this.post.stats.is_pinned : false },
     isStandardPost () { return !this.explorePost },

--- a/components/Report.vue
+++ b/components/Report.vue
@@ -18,6 +18,7 @@
           :cardData="report"
           modalTarget="#reportModal"
           :snippet="reportDescription"
+          :readMoreUrl="report.url"
           expandableSnippet
           :imageLoadFailed="imageLoadFailed"
           :imageLoading="imageLoading"
@@ -58,7 +59,7 @@
         >
           <!-- Slot for the report-specific right-side actions -->
           <template #extra-actions>
-            <social-sharing :url="'https://actifit.io/@' + report.author + '/' + report.permlink" :title="report.title" :description="socialSharingDesc" :quote="socialSharingQuote" :hashtags="hashtags" twitter-user="actifit_fitness" inline-template>
+            <social-sharing :url="'https://actifit.io/@' + report.author + '/' + report.permlink" :title="report.title" :description="socialSharingDesc" :quote="socialSharingQuote" :hashtags="hashtags" twitter-user="actifit_fitness" network-tag="a" inline-template>
               <span class="share-links-actifit">
                 <network network="twitter"><i class="fab fa-x-twitter text-brand" title="X (twitter)"></i></network>
               </span>
@@ -231,4 +232,29 @@ export default {
 .check-tooltip { color: white; }
 .card { box-shadow: 3px 3px 3px rgb(255 0 0 / 40%); }
 .payoutCustomDisplay { line-height: 1.5; }
+
+/* Normalize the share (X) button to match the blog card — same size / spacing as its siblings */
+.share-links-actifit {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.share-links-actifit ::v-deep a,
+.share-links-actifit ::v-deep button {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 4px;
+  line-height: 1;
+  color: inherit;
+  text-decoration: none;
+  transition: color .15s ease;
+}
+.share-links-actifit ::v-deep a:hover,
+.share-links-actifit ::v-deep button:hover,
+.share-links-actifit ::v-deep a:hover i,
+.share-links-actifit ::v-deep button:hover i {
+  color: #ff112d !important;
+}
 </style>


### PR DESCRIPTION
Three card-view alignment issues found in QA:

## 1. X/share icon oversized/misaligned on the activity card
`Report.vue`'s `social-sharing` was missing `network-tag="a"`, so the X rendered as a raw `<network>` element with none of the `.share-links-actifit` normalization that `Post.vue` applies — it looked bigger and sat misaligned next to the chart/book. Added `network-tag="a"` + the same share-links CSS. **Now the activity X is a 24px `<a>`, same size as the blog X and aligned with its siblings.**

## 2. "Read more" opened a modal — now opens a new tab (both cards)
Both cards' read-more went through CardBody's modal (`open-modal`). Per request, changed the snippet link, the **Read more** toggle, and the book icon to open the post in a **new tab** (`:href` + `target="_blank"`) instead. Added a `readMoreUrl` prop to the shared `CardBody`. (The image click still opens the inline modal.)

## 3. Blog post links missing community + @
`Post.vue` `buildLink` returned `/author/permlink`; the activity card uses the full `/community/@author/permlink`. Switched `buildLink` to `post.url`, so blog links now match — e.g. `/hive-177727/@hdev/…`.

## Verified (headless)
- Activity X wrapper now 24px (`<a>`), matching blog; aligned with the chart button.
- Blog title/snippet/book links = `/hive-177727/@hdev/…` with `target=_blank`.
- Activity read-more is an `<a target=_blank>` to `/hive-193552/@…`.
- eslint clean.