### PR TITLE
fix(cards): body-text opens modal like image; blog uses 'Read more' text

### DIFF
--- a/components/CardBody.vue
+++ b/components/CardBody.vue
@@ -45,10 +45,11 @@
       <div class="col-12">
         <div v-if="expandableSnippet" class="report-snippet-section">
           <a
-            :href="readMoreUrl"
-            target="_blank"
-            rel="noopener noreferrer"
+            href="#"
             class="report-snippet-link"
+            @click.prevent="$emit('open-modal')"
+            :data-toggle="modalTarget ? 'modal' : null"
+            :data-target="modalTarget"
             :title="$t('read_more_small')"
           >
             <div

--- a/components/Post.vue
+++ b/components/Post.vue
@@ -32,8 +32,9 @@
 
           :cardData="post"
           modalTarget="#postModal"
-          :snippet="bodySnippet"
+          :snippet="postDescription"
           :readMoreUrl="buildLink"
+          expandableSnippet
           :imageLoadFailed="imageLoadFailed"
           :imageLoading="imageLoading"
           :imageGeneration="imageGeneration"
@@ -128,6 +129,12 @@ export default {
     // END: ADDED COMPUTED PROPERTY
     isOnlyPost () { return this.userPosts && this.userPosts.length === 1 },
     buildLink () { return this.post.url || ('/' + this.post.author + '/' + this.post.permlink) },
+    // full cleaned body (like Report.vue's reportDescription) so CardBody clamps it and shows
+    // "Read more" on overflow — bodySnippet is pre-truncated to 150 and never overflows
+    postDescription () {
+      if (!this.post || !this.post.body) return ''
+      return this.$cleanBody(this.post.body, true, true).replace(/<[^>]+>/g, '')
+    },
     isPostReblog () { return this.displayUsername && this.displayUsername !== this.post.author },
     isPostPinned () { return this.post.stats ? this.post.stats.is_pinned : false },
     isStandardPost () { return !this.explorePost },


### PR DESCRIPTION
Two more card-view alignment fixes:

## 1. Body text click → modal (same as the image)
Clicking the body-snippet text now opens the inline modal, matching the image click. The explicit **Read more** link and the book icon still open the post in a **new tab** (from the previous PR), so: image + body text → modal; Read more + book → new tab, consistently on both cards.

## 2. Blog card shows the 'Read more' text (not the ⤢ icon)
Switched `Post.vue`'s CardBody to `expandableSnippet` mode so the blog card renders the **Read more** text like the activity card, instead of the external-link icon.

`bodySnippet` was pre-truncated to 150 chars, so CardBody's overflow detection never fired and the toggle never showed — added a `postDescription` computed (full cleaned body, like `reportDescription`) so CardBody clamps it visually and shows **Read more** on overflow.

## Verified (headless)
- Blog + activity: body-snippet link `href="#"` + `data-toggle="modal"` (opens modal); **Read more** is a visible `<a target=_blank>`; no external-link icon.
- eslint clean.