### PR TITLE
chore(release): bump version to 1.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "actifit-landingpage",
-      "version": "1.12.2",
+      "version": "1.13.0",
       "hasInstallScript": true,
       "dependencies": {
         "@blurtfoundation/blurtjs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actifit-landingpage",
-  "version": "1.12.2",
+  "version": "1.13.0",
   "description": "Actifit is an innovative dapp that aims to incentivize fitness and healthy lifestyle via rewarding daily activity.",
   "author": "mktcode",
   "private": true,


### PR DESCRIPTION
Version bump **1.12.2 → 1.13.0** ahead of the next production deploy.

This tags the body of work that has landed on `develop` since v1.12.2 was deployed to production (`master`) on **2026-08-10**, so the upcoming `develop → master` deploy carries a clean version number.

### Rolled up in 1.13.0 (undeployed since 1.12.2)
- **Wallet / Market screen revamp** (#364, #377, #396, #403)
- **Unified wallet action bar + token search**; login-after-logout fix; filter-active state (#406, #407, #409)
- **Post action strip** restored to the header + color corrections (#410–#413)
- **Blog ↔ activity card-view alignment**: titles, X icon, read-more behavior, voted-upvote red, body-click → modal (#415–#418)
- Preview description field (#399), localized post-URL redirect (#400), navbar editor i18n (#401), blog-screen error fix (#398)
- Account-recovery key restore (#395), DHF popup disabled (#414), cookie-banner DHF (#397)
- 25 new i18n keys across all 14 locales (#408)

### Files
- `package.json`, `package-lock.json` — version field only.

### Pre-deploy checklist (for the follow-up develop → master PR)
- [ ] `npm ci` pre-flight passes (lockfile in sync)
- [ ] Decide on the 5 open Dependabot PRs
- [ ] Note the 2 pre-existing failing suites (StingChat, disable-email-obfuscation) — not release blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)