### PR TITLE
ci: run eslint + jest on every PR (#159)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+# Fast PR gate: run ESLint + Jest on every pull request so lint errors, broken
+# Vue 2 reactivity, unscoped CSS leaks, missing $t() keys and failing tests are
+# caught before review instead of in a review round (or in production).
+#
+# NOTE: no `paths:` filter. Once this is a *required* check in branch protection,
+# a path-skipped required check stays "pending" forever and blocks every PR that
+# doesn't touch matching files (GitHub gotcha — same reason lockfile-sync.yml has
+# none). Running on all PRs guarantees it always reports a status. The whole job
+# is ~2-3 min, dominated by `npm ci`.
+
+on:
+  pull_request:
+    branches: [develop, master]
+  workflow_dispatch:
+
+jobs:
+  lint-and-test:
+    name: eslint + jest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc' # v16.20.2, matching the DigitalOcean build
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+        env:
+          # skip the ~100MB Playwright browser download — jest unit tests don't need it
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+      - name: Lint (eslint)
+        run: npm run lint
+      - name: Unit tests (jest)
+        run: npm test

--- a/test/unit/components/StingChat.spec.js
+++ b/test/unit/components/StingChat.spec.js
@@ -158,6 +158,8 @@ describe('components/StingChat.vue', () => {
       widget,
       widgetSessionVersion: 0,
       isBeingDestroyed: false,
+      // chat was opened, so restartWidgetSession() rebuilds after teardown
+      widgetRequested: true,
       widgetError: '',
       $refs: { widgetContainer: container },
       $nextTick: (callback) => callback(),
@@ -319,7 +321,7 @@ describe('components/StingChat.vue', () => {
     expect(container.hidden).toBe(true)
   })
 
-  it('validates and attaches a prompted posting key without persisting it', () => {
+  it('validates and attaches a prompted posting key without persisting it', async () => {
     const postingKey = hive.auth.toWif('alice', 'posting-key-test', 'posting')
     const publicKey = hive.auth.wifToPublic(postingKey)
     const container = { hidden: true }
@@ -328,6 +330,7 @@ describe('components/StingChat.vue', () => {
       postingKeyInput: postingKey,
       postingKeyError: '',
       showPostingKeyPrompt: true,
+      widgetRequested: false,
       user: {
         account: {
           posting: { key_auths: [[publicKey, 1]] }
@@ -336,7 +339,9 @@ describe('components/StingChat.vue', () => {
       $store: store,
       $refs: { widgetContainer: container },
       $t: (key) => key,
-      $nextTick: (callback) => callback()
+      $nextTick: (callback) => callback(),
+      // submitPostingKey loads the widget on demand via ensureWidget()
+      ensureWidget: jest.fn(() => Promise.resolve())
     }
     vm.isValidPostingKey = (key) => StingChat.methods.isValidPostingKey.call(vm, key)
     vm.closePostingKeyPrompt = () => StingChat.methods.closePostingKeyPrompt.call(vm)
@@ -347,6 +352,11 @@ describe('components/StingChat.vue', () => {
     expect(localStorage.getItem('chatPostingKey')).toBeNull()
     expect(vm.postingKeyInput).toBe('')
     expect(vm.showPostingKeyPrompt).toBe(false)
+    expect(vm.ensureWidget).toHaveBeenCalledTimes(1)
+
+    // the container is revealed inside ensureWidget().then(...) — flush the microtask
+    await Promise.resolve()
+    await Promise.resolve()
     expect(container.hidden).toBe(false)
   })
 

--- a/test/unit/middleware/disable-email-obfuscation.spec.js
+++ b/test/unit/middleware/disable-email-obfuscation.spec.js
@@ -38,7 +38,9 @@ describe('disable-email-obfuscation middleware', () => {
     const page = fs.readFileSync(pagePath, 'utf8')
 
     expect(page).toContain("middleware: 'disable-email-obfuscation'")
-    expect(page).toContain('href="mailto:hello@actifit.io"')
+    // the page must carry a real, un-obfuscated actifit mail link (address varies
+    // per page — privacy uses info@, terms uses hello@)
+    expect(page).toMatch(/href="mailto:[a-z0-9._%+-]+@actifit\.io"/i)
     expect(page).not.toContain('/cdn-cgi/l/email-protection')
   })
 })


### PR DESCRIPTION
Implements Trello #159 — the repo had **no CI**; `eslint`/`jest` only ran when someone remembered locally. This adds a fast PR gate.

## What
- **`.github/workflows/ci.yml`** — runs on `pull_request` to `develop`/`master` (+ manual dispatch).
  - Node **16.20.2** via `.nvmrc` (matches the DigitalOcean build & `engines`)
  - `npm ci` with **npm dependency caching**, `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`
  - Steps: **`npm run lint`** then **`npm test`**
  - No `paths:` filter (a path-skipped *required* check hangs "pending" forever — same reasoning as `lockfile-sync.yml`)
  - Whole job ~2-3 min.

## Fixed the 3 pre-existing failures first (so the gate is green by default)
These were **stale tests**, not component bugs:
- **StingChat.spec.js (2):** the widget was refactored to load on demand via `ensureWidget()` and only rebuild when `widgetRequested` is set. Updated the specs to mock `ensureWidget`, set `widgetRequested`, and await the async reveal.
- **disable-email-obfuscation.spec.js (1):** it hard-coded `mailto:hello@actifit.io` for *both* pages, but `privacy-policy.vue` uses `info@` and `terms-conditions.vue` uses `hello@`. Now asserts a real, un-obfuscated `@actifit.io` mail link via regex.

Local run after fixes: **43/43 suites, 328/328 tests pass; eslint clean.**

## After merge (repo admin, not code)
- Make **eslint + jest** a **required** status check on `develop` (Settings → Branches), like `lockfile-sync`, so a red PR can't merge.

## Deferred (card's optional "nice-to-have")
- The **lang-key guard** test (regex every `$t('…')` and assert the key exists in all 14 `lang/*.js`) — left as a follow-up so this PR ships a guaranteed-green gate; adding it now risks red-by-default if any stray key is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)