### PR TITLE
fix(wallet): refresh balances/profile on Switch User

### DIFF
--- a/pages/_username/wallet.vue
+++ b/pages/_username/wallet.vue
@@ -2556,11 +2556,22 @@ export default {
       immediate: true,
       handler: async function (newVal, oldVal) {
         if (newVal && (!oldVal || newVal.name !== oldVal.name)) {
-          // If the page mounted while logged out (self /wallet), its init never
-          // ran — run it now that the visitor has logged in, before refreshing.
-          if (this.mountedDone && !this.walletInitialized
-              && !(this.$route.params && this.$route.params.username)) {
-            await this.initWallet(newVal.name);
+          // Only the self /wallet (no :username in the route) tracks the logged-in user.
+          if (this.mountedDone && !(this.$route.params && this.$route.params.username)) {
+            const switchedUser = oldVal && newVal.name !== oldVal.name;
+            if (switchedUser) {
+              // Switch User: clear the init guard so we re-point the wallet at the
+              // newly active account. Without this, displayUser/displayUserData stay
+              // on the old user and every balance/profile refresh below refetches the
+              // WRONG account. initWallet() re-sets displayUser + displayUserData for
+              // the new user (it keeps the old data until the fresh fetch resolves, so
+              // no null-deref flash).
+              this.walletInitialized = false;
+            }
+            // First login after a logged-out mount, or a just-cleared switch: (re)init.
+            if (!this.walletInitialized) {
+              await this.initWallet(newVal.name);
+            }
           }
           await this.refreshAllWalletData();
         }


### PR DESCRIPTION
**Bug:** on the self `/wallet`, using **Switch User** left the *old* account's profile and balances on screen (e.g. logged in as `@actifit.social` but still showing `actifit.rewards`'s wallet).

**Cause:** the `user.account` watcher only ran `initWallet()` on *first* login (guarded by `walletInitialized`). On a switch it skipped init, so `displayUser` / `displayUserData` stayed on the previous account and every balance/profile refresh refetched the **wrong** user.

**Fix:** when the logged-in account name actually changes on the self `/wallet`, clear the `walletInitialized` guard and re-run `initWallet()` for the new user — which re-points `displayUser` + `displayUserData` and refetches everything. `initWallet` keeps the old `displayUserData` until the fresh fetch resolves, so there's **no null-deref flash** (an earlier attempt that nulled it mid-switch crashed the render — avoided here).

**Verified headlessly:** mount `/wallet` logged-out → inject `actifit` (first-login path) → then `from-mars` (switch path). `displayUser` and `displayUserData` both flip `actifit → from-mars`; before the fix they stayed on `actifit`. eslint clean.

Only touches the `user.account` watcher; `:username`-scoped wallet views (viewing someone else's wallet) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)