### PR TITLE
fix(wallet): claimable rewards section persists after a successful claim

### DIFF
--- a/pages/_username/wallet.vue
+++ b/pages/_username/wallet.vue
@@ -4719,6 +4719,44 @@ export default {
         console.error('Error in fetchTokenBalance:', err);
       }
     },
+    zeroClaimableDisplay() {
+      // Reflect a just-succeeded claim immediately. The claimable section is driven
+      // by these values, and node propagation lags the tx, so without an optimistic
+      // clear the just-claimed pending balance intermittently keeps showing.
+      this.claimVests = '0.000000 VESTS';
+      this.claimSP = '0.000 POWER';
+      this.claimSBD = (this.cur_bchain === 'STEEM') ? '0.000 SBD' : '0.000 HBD';
+      this.claimSTEEM = (this.cur_bchain === 'BLURT') ? '0.000 BLURT'
+        : (this.cur_bchain === 'STEEM') ? '0.000 STEEM' : '0.000 HIVE';
+    },
+    rewardBalancesCleared(acct) {
+      // true once the chain shows no unclaimed reward balances on the account
+      const num = v => parseFloat((v || '0').toString().split(' ')[0]) || 0;
+      return num(acct.reward_vesting_balance) === 0
+        && num(acct.reward_hive_balance || acct.reward_steem_balance || acct.reward_blurt_balance) === 0
+        && num(acct.reward_hbd_balance || acct.reward_sbd_balance) === 0;
+    },
+    async pollClaimableUntilCleared(attempts = 5, delayMs = 3000) {
+      // A single fixed-delay refetch is unreliable — the node may not have applied
+      // the claim yet, so the pending balance reappears (the reported intermittent
+      // bug). Poll until the chain confirms the reward balances are zero, then sync
+      // displayUserData and re-derive the claimable values.
+      const chainLnk = this.setProperNode();
+      for (let i = 0; i < attempts; i++) {
+        await new Promise(r => setTimeout(r, delayMs));
+        try {
+          const res = await chainLnk.api.getAccountsAsync([this.displayUser]);
+          if (res && res.length && this.rewardBalancesCleared(res[0])) {
+            this.displayUserData = res[0];
+            this.claimableSTEEMRewards();
+            break;
+          }
+        } catch (e) {
+          console.error('pollClaimableUntilCleared error:', e);
+        }
+      }
+      this.fetchUserData();
+    },
     async claimRewards() {
       //function handles claiming STEEM rewards
       if (!localStorage.getItem('std_login')) {
@@ -4732,7 +4770,9 @@ export default {
         }, window.location.origin + '/wallet?op=claim rewards&status=success');
 
         window.open(link);
-        setTimeout(() => this.fetchUserData(), 3000);
+        // The claim is signed in the SC popup; we don't get a success callback here,
+        // so poll the chain and only clear the section once it confirms zero rewards.
+        this.pollClaimableUntilCleared();
 
         //Below would have been preferred approach, but claimRewardBalance keeps failing as it requires more authority. Keeping here for future further exploration
         /*
@@ -4773,8 +4813,11 @@ export default {
         console.log(res.success);
         if (res.success) {
           this.confirmCompletion('claimrewards', 0, res);
-          //this.isClaimableDataAvailableTEMP = false;
-          setTimeout(() => this.fetchUserData(), 3000);
+          this.claimRewardsProcess = false;
+          // Broadcast confirmed: clear the section immediately, then reconcile with
+          // the chain (rides out node-propagation lag instead of one fixed 3s guess).
+          this.zeroClaimableDisplay();
+          this.pollClaimableUntilCleared();
         }
         /*steem.broadcast.claimRewardBalanceAsync(this.user.account.name,this.claimSTEEM, this.claimSBD, this.claimSP).then(
           res => ).catch(err=>console.log(err));*/


### PR DESCRIPTION
**Bug (intermittent):** claiming HIVE/HP rewards shows the success message, but the **Claimable HIVE Rewards** section still shows the just-claimed pending balance — as if it wasn't claimed.

**Cause:** the claimable values (`claimSTEEM` / `claimSP` / `claimVests` / `claimSBD`) are derived from `displayUserData.reward_*`. On claim success the page only did a single fixed `setTimeout(fetchUserData, 3000)` — but `fetchUserData()` no longer refetches `displayUserData` (it was intentionally removed), so the reward balances (and the section) didn't reliably refresh. Node-propagation lag made whether it cleared **intermittent**.

**Fix:**
- **Confirmed-success (keychain / posting-key) path:** optimistically clear the claimable display immediately — the section is driven by those values, so it reflects the claim right away.
- **Replace the fixed `setTimeout`** with `pollClaimableUntilCleared()`: refetch the account and only sync `displayUserData` + re-derive once the chain **confirms** the reward balances are zero (rides out propagation lag; up to 5×3s).
- **SteemConnect path** (no in-window success callback): also polls, but clears **only after** the chain confirms zero — so a cancelled SC popup won't wrongly clear the section.

eslint clean. Note: the end-to-end claim can't be verified headlessly (requires signing a real `claim_reward_balance` tx), but the optimistic clear deterministically fixes the reported symptom and the poll reconciles the real balances — worth a quick manual confirm on a live claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)